### PR TITLE
Redesign UI: green brand identity, bolder landing hero, polished component system

### DIFF
--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -6,26 +6,26 @@ import Link from "next/link";
 import Image from "next/image";
 
 const productLinks = [
-  { href: "/play", label: "Play" },
+  { href: "/play",    label: "Play" },
   { href: "/tickets", label: "Tickets" },
-  { href: "/host", label: "Host" },
+  { href: "/host",    label: "Host" },
   { href: "/profile", label: "Profile" },
 ];
 
 const companyLinks = [
-  { href: "/about", label: "About Meda" },
+  { href: "/about",         label: "About Meda" },
   { href: "/create-events", label: "Create a match" },
 ];
 
 const legalLinks = [
-  { href: "/privacy", label: "Privacy policy" },
-  { href: "/terms", label: "Terms & conditions" },
+  { href: "/privacy",       label: "Privacy policy" },
+  { href: "/terms",         label: "Terms & conditions" },
   { href: "/cookie-policy", label: "Cookie policy" },
-  { href: "/site-map", label: "Sitemap" },
+  { href: "/site-map",      label: "Sitemap" },
 ];
 
 const supportLinks = [
-  { href: "/help", label: "Help center" },
+  { href: "/help",                  label: "Help center" },
   { href: "mailto:support@meda.app", label: "support@meda.app" },
 ];
 
@@ -33,38 +33,53 @@ export default function Footer() {
   const year = new Date().getFullYear();
 
   return (
-    <footer className="relative mt-16 border-t border-[var(--color-border)] bg-[var(--footer-bg)]">
+    <footer className="relative mt-16 border-t border-[var(--color-border)]" style={{ background: "var(--footer-bg)" }}>
+      {/* Subtle glows */}
       <div className="pointer-events-none absolute inset-0 overflow-hidden">
-        <div className="absolute left-0 top-0 h-48 w-48 rounded-full bg-[rgba(56,189,248,0.14)] blur-3xl" />
-        <div className="absolute bottom-0 right-10 h-56 w-56 rounded-full bg-[rgba(52,211,153,0.12)] blur-3xl" />
+        <div className="absolute left-0 top-0 h-52 w-52 rounded-full bg-[rgba(74,222,128,0.08)] blur-3xl" />
+        <div className="absolute bottom-0 right-10 h-60 w-60 rounded-full bg-[rgba(56,189,248,0.06)] blur-3xl" />
       </div>
 
       <div className="page-container relative space-y-8 pb-[calc(var(--bottom-nav-height)+var(--space-6)+env(safe-area-inset-bottom,0px))] pt-10 md:space-y-10 md:pb-12 md:pt-16">
-        <div className="grid gap-8 lg:grid-cols-[1.1fr_1fr] lg:gap-10">
+        <div className="grid gap-8 lg:grid-cols-[1.15fr_1fr] lg:gap-12">
+          {/* Brand column */}
           <div className="space-y-5">
-            <div className="flex items-center gap-3 sm:gap-4">
-              <Image src="/logo-White.svg" alt="Meda" width={48} height={48} className="h-11 w-11 sm:h-12 sm:w-12" />
+            <div className="flex items-center gap-3">
+              <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-[rgba(74,222,128,0.2)] bg-[rgba(74,222,128,0.08)]">
+                <Image
+                  src="/logo-White.svg"
+                  alt="Meda"
+                  width={32}
+                  height={32}
+                  className="h-7 w-7"
+                />
+              </div>
               <div>
-                <p className="text-base font-semibold tracking-[-0.03em] text-[var(--color-text-primary)]">Meda</p>
-                <p className="text-sm text-[var(--color-text-muted)]">Play, tickets, and hosting in one place.</p>
+                <p className="text-base font-bold tracking-[-0.03em] text-[var(--color-text-primary)]">
+                  Meda
+                </p>
+                <p className="text-xs text-[var(--color-text-muted)]">
+                  Play, tickets, and hosting in one place.
+                </p>
               </div>
             </div>
 
-            <p className="max-w-2xl text-sm leading-7 text-[var(--color-text-secondary)] sm:text-base">
-              Built for pickup football in Ethiopia: easier match discovery, clearer ticket flows,
-              simpler hosting tools, and payments that make sense the first time you use them.
+            <p className="max-w-2xl text-sm leading-[1.8] text-[var(--color-text-secondary)]">
+              Built for pickup football in Ethiopia — easier match discovery, clearer ticket
+              flows, simpler hosting tools, and payments that make sense the first time you use them.
             </p>
 
-            <div className="flex flex-wrap gap-2.5 text-sm text-[var(--color-text-muted)]">
+            <div className="flex flex-wrap gap-2 text-xs text-[var(--color-text-muted)]">
               <span className="rounded-full border border-[var(--color-border)] bg-[var(--color-control-bg)] px-3 py-1.5">
                 Addis Ababa, built for Ethiopia
               </span>
               <span className="rounded-full border border-[var(--color-border)] bg-[var(--color-control-bg)] px-3 py-1.5">
-                Support: support@meda.app
+                support@meda.app
               </span>
             </div>
           </div>
 
+          {/* Links grid */}
           <div className="grid gap-6 sm:grid-cols-2 sm:gap-8">
             <FooterColumn title="Product" links={productLinks} />
             <FooterColumn title="Company" links={companyLinks} />
@@ -75,13 +90,13 @@ export default function Footer() {
 
         <div className="soft-divider" />
 
-        <div className="flex flex-col gap-4 text-sm text-[var(--color-text-muted)] md:flex-row md:items-center md:justify-between">
-          <p>(c) {year} Meda. All rights reserved.</p>
+        <div className="flex flex-col gap-4 text-xs text-[var(--color-text-muted)] md:flex-row md:items-center md:justify-between">
+          <p>&copy; {year} Meda. All rights reserved.</p>
           <div className="flex flex-wrap gap-2">
-            <span className="rounded-full border border-[rgba(125,211,252,0.18)] bg-[rgba(125,211,252,0.08)] px-3 py-1 text-xs font-semibold text-[var(--color-brand)]">
+            <span className="rounded-full border border-[rgba(74,222,128,0.22)] bg-[rgba(74,222,128,0.08)] px-3 py-1 font-semibold text-[var(--color-brand)]">
               Secure payments
             </span>
-            <span className="rounded-full border border-[rgba(52,211,153,0.18)] bg-[rgba(52,211,153,0.08)] px-3 py-1 text-xs font-semibold text-[var(--color-brand-alt)]">
+            <span className="rounded-full border border-[rgba(125,211,252,0.2)] bg-[rgba(125,211,252,0.07)] px-3 py-1 font-semibold text-[var(--color-brand-alt)]">
               Built for night games
             </span>
           </div>
@@ -104,11 +119,17 @@ function FooterColumn({ title, links }: FooterColumnProps) {
         {links.map((link) => (
           <li key={link.href}>
             {link.href.startsWith("mailto:") ? (
-              <a href={link.href} className="transition hover:text-[var(--color-text-primary)]">
+              <a
+                href={link.href}
+                className="transition hover:text-[var(--color-brand)]"
+              >
                 {link.label}
               </a>
             ) : (
-              <Link href={link.href} className="transition hover:text-[var(--color-text-primary)]">
+              <Link
+                href={link.href}
+                className="transition hover:text-[var(--color-brand)]"
+              >
                 {link.label}
               </Link>
             )}

--- a/app/components/HeaderNav.tsx
+++ b/app/components/HeaderNav.tsx
@@ -1,7 +1,5 @@
 /**
  * HeaderNav -- main navigation bar with logo, links, and auth state.
- *
- * Shows UserButton when signed in; sign-in when signed out.
  */
 
 "use client";
@@ -63,25 +61,23 @@ export default function HeaderNav({ initialSession = null }: HeaderNavProps) {
         const nextBalance = Number(data.balanceEtb) || 0;
         setBalance(nextBalance > 0 ? nextBalance : null);
       } catch {
-        // Ignore balance failures in chrome.
+        // Ignore balance failures silently.
       }
     };
-
     void load();
   }, [isLoggedIn]);
 
   useEffect(() => {
     if (!mobileMenuOpen) return;
-    const originalOverflow = document.body.style.overflow;
+    const orig = document.body.style.overflow;
     document.body.style.overflow = "hidden";
-    return () => {
-      document.body.style.overflow = originalOverflow;
-    };
+    return () => { document.body.style.overflow = orig; };
   }, [mobileMenuOpen]);
 
-  const desktopLinks = useMemo(() => {
-    return filterNavItems(primaryDesktopNav, { isLoggedIn, isPitchOwner });
-  }, [isLoggedIn, isPitchOwner]);
+  const desktopLinks = useMemo(
+    () => filterNavItems(primaryDesktopNav, { isLoggedIn, isPitchOwner }),
+    [isLoggedIn, isPitchOwner],
+  );
 
   const mobileTabs = useMemo(
     () =>
@@ -93,22 +89,21 @@ export default function HeaderNav({ initialSession = null }: HeaderNavProps) {
   );
   const showBottomNav = mobileTabs.length > 1;
 
-  const isTabActive = (href: string) => {
-    return isNavPathActive(pathname, href);
-  };
+  const isTabActive = (href: string) => isNavPathActive(pathname, href);
 
-  const desktopLinkClasses = (href: string) => {
+  const desktopLinkClass = (href: string) => {
     const active = isTabActive(href);
     return cn(
       "rounded-full px-4 py-2 text-sm font-medium tracking-[-0.01em] transition",
       active
-        ? "border border-[rgba(125,211,252,0.22)] bg-[var(--color-accent-soft)] text-[var(--color-text-primary)]"
+        ? "border border-[rgba(74,222,128,0.3)] bg-[var(--color-accent-soft)] text-[var(--color-text-primary)]"
         : "text-[var(--color-text-secondary)] hover:bg-[var(--color-control-bg-hover)] hover:text-[var(--color-text-primary)]",
     );
   };
 
   return (
     <>
+      {/* Skip link */}
       <a
         href="#main-content"
         className="sr-only z-[80] rounded-md bg-[var(--color-brand)] px-4 py-2 text-sm font-semibold text-[var(--color-brand-text)] focus:not-sr-only focus:fixed focus:left-4 focus:top-4"
@@ -116,53 +111,62 @@ export default function HeaderNav({ initialSession = null }: HeaderNavProps) {
         Skip to main content
       </a>
 
+      {/* ── Header bar ──────────────────────────────── */}
       <header className="fixed inset-x-0 top-0 z-50 pt-[calc(env(safe-area-inset-top,0px)+8px)]">
         <div className="site-container">
-          <div className="surface-card flex min-h-[56px] items-center justify-between gap-3 rounded-[26px] px-2.5 py-2 sm:min-h-[60px] sm:gap-4 sm:px-4">
-            <div className="flex min-w-0 items-center gap-3 sm:gap-5">
-              <Link href="/" className="flex items-center gap-3 text-[var(--color-text-primary)]">
+          <div className="surface-card flex min-h-[58px] items-center justify-between gap-3 rounded-[28px] px-2.5 py-2 sm:min-h-[62px] sm:gap-4 sm:px-3.5">
+            {/* Logo + desktop nav */}
+            <div className="flex min-w-0 items-center gap-2 sm:gap-4">
+              <Link
+                href="/"
+                className="flex items-center gap-2.5 text-[var(--color-text-primary)] sm:gap-3"
+              >
                 <Image
                   src="/logo-White.svg"
                   alt="Meda"
-                  width={42}
-                  height={42}
-                  className="h-9 w-9 shrink-0 sm:h-10 sm:w-10"
+                  width={40}
+                  height={40}
+                  className="h-8 w-8 shrink-0 sm:h-9 sm:w-9"
                 />
                 <div className="hidden min-w-0 md:block">
-                  <p className="text-sm font-semibold tracking-[-0.02em]">Meda</p>
-                  <p className="text-xs text-[var(--color-text-muted)]">Play, tickets, and hosting</p>
+                  <p className="text-sm font-bold tracking-[-0.03em]">Meda</p>
+                  <p className="text-[0.72rem] text-[var(--color-text-muted)]">
+                    Play, tickets & hosting
+                  </p>
                 </div>
               </Link>
 
-              <nav className="hidden items-center gap-1 lg:flex">
+              <nav className="hidden items-center gap-0.5 lg:flex">
                 {desktopLinks.map((link) => (
-                  <Link key={link.href} href={link.href} className={desktopLinkClasses(link.href)}>
+                  <Link key={link.href} href={link.href} className={desktopLinkClass(link.href)}>
                     {link.label}
                   </Link>
                 ))}
               </nav>
             </div>
 
-            <div className="flex items-center gap-2 sm:gap-3">
+            {/* Right side */}
+            <div className="flex items-center gap-2 sm:gap-2.5">
               {balance != null ? (
                 <Link
                   href="/profile"
-                  className="hidden items-center gap-1.5 rounded-full border border-[rgba(125,211,252,0.24)] bg-[var(--color-accent-soft)] px-3 py-2 text-xs font-semibold text-[var(--color-text-primary)] md:inline-flex"
+                  className="hidden items-center gap-1.5 rounded-full border border-[rgba(74,222,128,0.3)] bg-[var(--color-accent-soft)] px-3 py-2 text-xs font-bold text-[var(--color-text-primary)] transition hover:border-[rgba(74,222,128,0.5)] hover:bg-[rgba(74,222,128,0.18)] md:inline-flex"
                 >
-                  <WalletIcon className="h-4 w-4 text-[var(--color-brand)]" />
-                  <span>ETB {balance.toFixed(2)}</span>
+                  <WalletIcon className="h-3.5 w-3.5 text-[var(--color-brand)]" />
+                  ETB {balance.toFixed(2)}
                 </Link>
               ) : null}
 
+              {/* Mobile menu trigger */}
               <button
                 type="button"
-                className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-[var(--color-border)] bg-[var(--color-control-bg)] text-[var(--color-text-primary)] lg:hidden"
+                className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-[var(--color-border)] bg-[var(--color-control-bg)] text-[var(--color-text-primary)] transition hover:bg-[var(--color-control-bg-hover)] lg:hidden"
                 onClick={() => setMobileMenuOpen(true)}
                 aria-label="Open menu"
                 aria-expanded={mobileMenuOpen}
                 aria-controls="mobile-menu-sheet"
               >
-                <MenuIcon className="h-5 w-5" />
+                <MenuIcon className="h-4.5 w-4.5" />
               </button>
 
               <SignedIn>
@@ -173,7 +177,10 @@ export default function HeaderNav({ initialSession = null }: HeaderNavProps) {
               <SignedOut>
                 <Link
                   href="/auth/sign-in"
-                  className={cn(buttonVariants("primary", "md"), "hidden rounded-full px-5 sm:inline-flex")}
+                  className={cn(
+                    buttonVariants("primary", "md"),
+                    "hidden rounded-full px-5 sm:inline-flex",
+                  )}
                 >
                   Sign in
                 </Link>
@@ -183,106 +190,85 @@ export default function HeaderNav({ initialSession = null }: HeaderNavProps) {
         </div>
       </header>
 
+      {/* ── Mobile full-screen menu ──────────────────── */}
       {mobileMenuOpen ? (
         <div className="fixed inset-0 z-[70] lg:hidden">
+          {/* Backdrop */}
           <button
             type="button"
-            className="absolute inset-0 bg-[rgba(2,6,23,0.72)] backdrop-blur-md"
+            className="absolute inset-0 bg-[rgba(2,5,14,0.76)] backdrop-blur-lg"
             onClick={() => setMobileMenuOpen(false)}
             aria-label="Close menu"
           />
+
           <div
             id="mobile-menu-sheet"
-            className="mobile-sheet absolute inset-x-0 bottom-0 top-[max(72px,env(safe-area-inset-top,0px)+68px)] overflow-y-auto px-5 pb-[calc(24px+env(safe-area-inset-bottom,0px))] pt-5"
+            className="mobile-sheet absolute inset-x-0 bottom-0 top-[max(74px,env(safe-area-inset-top,0px)+70px)] overflow-y-auto px-5 pb-[calc(28px+env(safe-area-inset-bottom,0px))] pt-6"
           >
-            <div className="mx-auto flex max-w-lg flex-col gap-5">
+            <div className="mx-auto flex max-w-lg flex-col gap-4">
+              {/* Header row */}
               <div className="flex items-start justify-between gap-3">
-                <div className="space-y-1">
+                <div className="space-y-0.5">
                   <p className="heading-kicker">Menu</p>
-                  <p className="text-lg font-semibold tracking-[-0.03em] text-[var(--color-text-primary)]">
-                    Move around the app without hunting for things.
+                  <p className="text-lg font-bold tracking-[-0.04em] text-[var(--color-text-primary)]">
+                    Where do you want to go?
                   </p>
                 </div>
                 <button
                   type="button"
-                  className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-[var(--color-border)] bg-[var(--color-control-bg)] text-[var(--color-text-primary)]"
+                  className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-[var(--color-border)] bg-[var(--color-control-bg)] text-[var(--color-text-primary)] transition hover:bg-[var(--color-control-bg-hover)]"
                   onClick={() => setMobileMenuOpen(false)}
                   aria-label="Close menu"
                 >
-                  <CloseIcon className="h-5 w-5" />
+                  <CloseIcon className="h-4 w-4" />
                 </button>
               </div>
 
-              <div className="surface-card-muted rounded-[24px] p-4">
+              {/* Auth / balance strip */}
+              <div className="surface-card-muted rounded-[18px] p-4">
                 <div className="flex items-center justify-between gap-3">
-                  <div>
-                    <p className="text-sm font-semibold text-[var(--color-text-primary)]">
-                      {isLoggedIn ? "Signed in" : "Welcome"}
-                    </p>
-                    <p className="text-sm text-[var(--color-text-secondary)]">
-                      {isLoggedIn
-                        ? "Open tickets, host tools, and your balance from here."
-                        : "Sign in to see your tickets, bookings, and hosting tools."}
-                    </p>
-                  </div>
+                  <p className="text-sm text-[var(--color-text-secondary)]">
+                    {isLoggedIn
+                      ? "Open tickets, host tools, and your balance from here."
+                      : "Sign in to see your tickets, bookings, and hosting tools."}
+                  </p>
                   {balance != null ? (
-                    <span className="rounded-full border border-[rgba(125,211,252,0.24)] bg-[var(--color-accent-soft)] px-3 py-1.5 text-sm font-semibold text-[var(--color-text-primary)]">
+                    <span className="shrink-0 rounded-full border border-[rgba(74,222,128,0.3)] bg-[var(--color-accent-soft)] px-3 py-1.5 text-sm font-bold text-[var(--color-text-primary)]">
                       ETB {balance.toFixed(0)}
                     </span>
                   ) : null}
                 </div>
               </div>
 
+              {/* Quick tools for owners/admins */}
               {(isPitchOwner || isAdmin) ? (
-                <div className="grid gap-3 rounded-[24px] border border-[var(--color-border)] bg-[var(--color-control-bg)] p-4">
-                  <div>
-                    <p className="text-sm font-semibold text-[var(--color-text-primary)]">
-                      Quick tools
-                    </p>
-                    <p className="text-sm text-[var(--color-text-secondary)]">
-                      Open the workspace that matches what you are trying to do.
-                    </p>
-                  </div>
+                <div className="rounded-[18px] border border-[var(--color-border)] bg-[var(--color-control-bg)] p-4">
+                  <p className="mb-3 text-sm font-bold text-[var(--color-text-primary)]">
+                    Quick tools
+                  </p>
                   <div className="grid gap-2">
                     {isPitchOwner ? (
-                      <Link
+                      <MenuRow
                         href={appRoutes.host}
-                        onClick={() => setMobileMenuOpen(false)}
-                        className="flex min-h-14 items-center justify-between rounded-[20px] border border-[var(--color-border)] bg-white/[0.03] px-4 py-3 text-left"
-                      >
-                        <span>
-                          <span className="block text-base font-semibold text-[var(--color-text-primary)]">
-                            Host
-                          </span>
-                          <span className="block text-sm text-[var(--color-text-secondary)]">
-                            Places, booking times, people, and money
-                          </span>
-                        </span>
-                        <ChevronRightIcon className="h-5 w-5 text-[var(--color-text-secondary)]" />
-                      </Link>
+                        label="Host"
+                        sub="Pitches, booking times, people, and money"
+                        onClose={() => setMobileMenuOpen(false)}
+                      />
                     ) : null}
                     {isAdmin ? (
-                      <Link
+                      <MenuRow
                         href={appRoutes.admin}
-                        onClick={() => setMobileMenuOpen(false)}
-                        className="flex min-h-14 items-center justify-between rounded-[20px] border border-[var(--color-border)] bg-white/[0.03] px-4 py-3 text-left"
-                      >
-                        <span>
-                          <span className="block text-base font-semibold text-[var(--color-text-primary)]">
-                            Admin
-                          </span>
-                          <span className="block text-sm text-[var(--color-text-secondary)]">
-                            Users, billing, stats, and moderation
-                          </span>
-                        </span>
-                        <ChevronRightIcon className="h-5 w-5 text-[var(--color-text-secondary)]" />
-                      </Link>
+                        label="Admin"
+                        sub="Users, billing, stats, and moderation"
+                        onClose={() => setMobileMenuOpen(false)}
+                      />
                     ) : null}
                   </div>
                 </div>
               ) : null}
 
-              <nav className="grid gap-3" aria-label="Mobile menu">
+              {/* Main nav links */}
+              <nav className="grid gap-2" aria-label="Mobile navigation">
                 {desktopLinks.map((link) => {
                   const active = isTabActive(link.href);
                   return (
@@ -291,14 +277,14 @@ export default function HeaderNav({ initialSession = null }: HeaderNavProps) {
                       href={link.href}
                       onClick={() => setMobileMenuOpen(false)}
                       className={cn(
-                        "flex min-h-14 items-center justify-between rounded-[22px] border px-4 py-3 text-left",
+                        "flex min-h-[52px] items-center justify-between rounded-[18px] border px-4 py-3 text-left transition",
                         active
-                          ? "border-[rgba(125,211,252,0.3)] bg-[var(--color-accent-soft)] text-[var(--color-text-primary)]"
-                          : "border-[var(--color-border)] bg-[var(--color-control-bg)] text-[var(--color-text-secondary)]",
+                          ? "border-[rgba(74,222,128,0.35)] bg-[var(--color-accent-soft)] text-[var(--color-text-primary)]"
+                          : "border-[var(--color-border)] bg-[var(--color-control-bg)] text-[var(--color-text-secondary)] hover:border-[rgba(74,222,128,0.2)] hover:text-[var(--color-text-primary)]",
                       )}
                     >
-                      <span className="text-base font-semibold">{link.label}</span>
-                      <ChevronRightIcon className="h-5 w-5" />
+                      <span className="text-[0.95rem] font-semibold">{link.label}</span>
+                      <ChevronRightIcon className="h-4 w-4 opacity-50" />
                     </Link>
                   );
                 })}
@@ -306,46 +292,57 @@ export default function HeaderNav({ initialSession = null }: HeaderNavProps) {
                   <Link
                     href={appRoutes.createMatch}
                     onClick={() => setMobileMenuOpen(false)}
-                    className="flex min-h-14 items-center justify-between rounded-[22px] border border-[var(--color-border)] bg-[var(--color-control-bg)] px-4 py-3 text-left text-[var(--color-text-secondary)]"
+                    className="flex min-h-[52px] items-center justify-between rounded-[18px] border border-[var(--color-border)] bg-[var(--color-control-bg)] px-4 py-3 text-left transition hover:border-[rgba(74,222,128,0.2)] hover:text-[var(--color-text-primary)]"
                   >
                     <span>
-                      <span className="block text-base font-semibold text-[var(--color-text-primary)]">
+                      <span className="block text-[0.95rem] font-semibold text-[var(--color-text-primary)]">
                         Create match
                       </span>
-                      <span className="block text-sm">Optional event flow for hosts</span>
+                      <span className="block text-xs text-[var(--color-text-muted)]">
+                        Optional event flow for hosts
+                      </span>
                     </span>
-                    <ChevronRightIcon className="h-5 w-5" />
+                    <ChevronRightIcon className="h-4 w-4 opacity-50" />
                   </Link>
                 ) : null}
               </nav>
 
-              <div className="grid gap-3 rounded-[24px] border border-[var(--color-border)] bg-[var(--color-control-bg)] p-4 text-sm text-[var(--color-text-secondary)]">
-                <Link href="/help" className="font-medium text-[var(--color-text-primary)]">
-                  Help center
-                </Link>
-                <Link
-                  href="/site-map"
-                  onClick={() => setMobileMenuOpen(false)}
-                  className="font-medium text-[var(--color-text-primary)]"
-                >
-                  Browse all pages
-                </Link>
-                <a href="mailto:support@meda.app" className="font-medium text-[var(--color-text-primary)]">
-                  support@meda.app
-                </a>
+              {/* Support links */}
+              <div className="rounded-[18px] border border-[var(--color-border)] bg-[var(--color-control-bg)] p-4">
+                <p className="mb-2.5 text-xs font-bold uppercase tracking-[0.15em] text-[var(--color-text-muted)]">
+                  Support
+                </p>
+                <div className="grid gap-2.5 text-sm font-medium text-[var(--color-text-primary)]">
+                  <Link href="/help" className="transition hover:text-[var(--color-brand)]">
+                    Help center
+                  </Link>
+                  <Link
+                    href="/site-map"
+                    onClick={() => setMobileMenuOpen(false)}
+                    className="transition hover:text-[var(--color-brand)]"
+                  >
+                    Browse all pages
+                  </Link>
+                  <a
+                    href="mailto:support@meda.app"
+                    className="transition hover:text-[var(--color-brand)]"
+                  >
+                    support@meda.app
+                  </a>
+                </div>
               </div>
 
               <SignedOut>
                 <Link
                   href="/auth/sign-in"
                   onClick={() => setMobileMenuOpen(false)}
-                  className={cn(buttonVariants("primary", "md"), "w-full rounded-full")}
+                  className={cn(buttonVariants("primary", "lg"), "w-full rounded-full")}
                 >
                   Sign in
                 </Link>
               </SignedOut>
               <SignedIn>
-                <div className="surface-card-muted rounded-[24px] p-3">
+                <div className="surface-card-muted rounded-[18px] p-3">
                   <div className="flex items-center justify-between gap-3">
                     <p className="text-sm text-[var(--color-text-secondary)]">
                       Open your account menu for profile and sign-out.
@@ -361,13 +358,14 @@ export default function HeaderNav({ initialSession = null }: HeaderNavProps) {
         </div>
       ) : null}
 
+      {/* ── Mobile bottom tab bar ────────────────────── */}
       {showBottomNav ? (
         <nav
-          className="fixed bottom-[max(10px,env(safe-area-inset-bottom,0px))] left-1/2 z-50 w-[calc(100%-20px)] max-w-sm -translate-x-1/2 md:hidden"
+          className="fixed bottom-[max(10px,env(safe-area-inset-bottom,0px))] left-1/2 z-50 w-[calc(100%-24px)] max-w-sm -translate-x-1/2 md:hidden"
           aria-label="Primary"
         >
           <div
-            className="surface-card grid items-stretch rounded-[22px] px-1.5 py-1.5"
+            className="surface-card grid items-stretch rounded-[24px] px-1.5 py-1.5"
             style={{ gridTemplateColumns: `repeat(${mobileTabs.length}, minmax(0, 1fr))` }}
           >
             {mobileTabs.map((tab) => {
@@ -378,16 +376,18 @@ export default function HeaderNav({ initialSession = null }: HeaderNavProps) {
                   key={tab.href}
                   href={tab.href}
                   className={cn(
-                    "relative flex min-w-0 flex-col items-center justify-center gap-1 rounded-[16px] px-2 py-2.5 text-[0.7rem] font-semibold transition",
+                    "relative flex min-w-0 flex-col items-center justify-center gap-1 rounded-[18px] px-2 py-2.5 text-[0.68rem] font-semibold transition",
                     active
                       ? "bg-[var(--color-accent-soft)] text-[var(--color-text-primary)]"
                       : "text-[var(--color-text-secondary)] hover:bg-[var(--color-control-bg-hover)] hover:text-[var(--color-text-primary)]",
                   )}
                 >
-                  <Icon className={cn("h-5 w-5", active && "text-[var(--color-brand)]")} />
+                  <Icon
+                    className={cn("h-[18px] w-[18px]", active && "text-[var(--color-brand)]")}
+                  />
                   <span className="truncate">{tab.label}</span>
                   {active ? (
-                    <span className="absolute inset-x-3 bottom-0 h-0.5 rounded-full bg-[var(--color-brand)]" />
+                    <span className="absolute inset-x-4 bottom-0.5 h-0.5 rounded-full bg-[var(--color-brand)]" />
                   ) : null}
                 </Link>
               );
@@ -399,17 +399,41 @@ export default function HeaderNav({ initialSession = null }: HeaderNavProps) {
   );
 }
 
+/* ── Helper components ──────────────────────────────────── */
+
+function MenuRow({
+  href,
+  label,
+  sub,
+  onClose,
+}: {
+  href: string;
+  label: string;
+  sub: string;
+  onClose: () => void;
+}) {
+  return (
+    <Link
+      href={href}
+      onClick={onClose}
+      className="flex min-h-[52px] items-center justify-between rounded-[16px] border border-[var(--color-border)] bg-white/[0.03] px-4 py-3 text-left transition hover:border-[rgba(74,222,128,0.25)]"
+    >
+      <span>
+        <span className="block text-[0.95rem] font-semibold text-[var(--color-text-primary)]">
+          {label}
+        </span>
+        <span className="block text-xs text-[var(--color-text-secondary)]">{sub}</span>
+      </span>
+      <ChevronRightIcon className="h-4 w-4 text-[var(--color-text-secondary)]" />
+    </Link>
+  );
+}
+
+/* ── Icons ──────────────────────────────────────────────── */
+
 function SearchIcon({ className }: { className?: string }) {
   return (
-    <svg
-      className={className}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
       <circle cx="11" cy="11" r="8" />
       <line x1="21" y1="21" x2="16.65" y2="16.65" />
     </svg>
@@ -418,15 +442,7 @@ function SearchIcon({ className }: { className?: string }) {
 
 function PlusIcon({ className }: { className?: string }) {
   return (
-    <svg
-      className={className}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
       <line x1="12" y1="5" x2="12" y2="19" />
       <line x1="5" y1="12" x2="19" y2="12" />
     </svg>
@@ -435,15 +451,7 @@ function PlusIcon({ className }: { className?: string }) {
 
 function TicketIcon({ className }: { className?: string }) {
   return (
-    <svg
-      className={className}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
       <path d="M2 9a3 3 0 0 1 3-3h14a3 3 0 0 1 3 3v0a3 3 0 0 1-3 3v0a3 3 0 0 1-3 3H5a3 3 0 0 1-3-3v0z" />
       <path d="M13 6v12" />
     </svg>
@@ -452,15 +460,7 @@ function TicketIcon({ className }: { className?: string }) {
 
 function UserIcon({ className }: { className?: string }) {
   return (
-    <svg
-      className={className}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
       <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
       <circle cx="12" cy="7" r="4" />
     </svg>
@@ -469,15 +469,7 @@ function UserIcon({ className }: { className?: string }) {
 
 function WalletIcon({ className }: { className?: string }) {
   return (
-    <svg
-      className={className}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
       <path d="M3 7.5A2.5 2.5 0 0 1 5.5 5H19a2 2 0 0 1 2 2v2H5.5A2.5 2.5 0 0 0 3 11.5v-4Z" />
       <path d="M3 11.5A2.5 2.5 0 0 1 5.5 9H21v8a2 2 0 0 1-2 2H5.5A2.5 2.5 0 0 1 3 16.5v-5Z" />
       <circle cx="16" cy="14" r="1" />
@@ -487,15 +479,7 @@ function WalletIcon({ className }: { className?: string }) {
 
 function MenuIcon({ className }: { className?: string }) {
   return (
-    <svg
-      className={className}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
       <line x1="4" y1="7" x2="20" y2="7" />
       <line x1="4" y1="12" x2="20" y2="12" />
       <line x1="4" y1="17" x2="20" y2="17" />
@@ -505,15 +489,7 @@ function MenuIcon({ className }: { className?: string }) {
 
 function CloseIcon({ className }: { className?: string }) {
   return (
-    <svg
-      className={className}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
       <line x1="18" y1="6" x2="6" y2="18" />
       <line x1="6" y1="6" x2="18" y2="18" />
     </svg>
@@ -522,15 +498,7 @@ function CloseIcon({ className }: { className?: string }) {
 
 function ChevronRightIcon({ className }: { className?: string }) {
   return (
-    <svg
-      className={className}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
       <polyline points="9 18 15 12 9 6" />
     </svg>
   );

--- a/app/components/landing/LandingHome.tsx
+++ b/app/components/landing/LandingHome.tsx
@@ -1,5 +1,5 @@
 /**
- * Landing page component -- hero section with featured events, categories, and city matches.
+ * Landing page — hero, featured slots, featured matches, category/city browse.
  */
 
 import type { ReactNode } from "react";
@@ -8,14 +8,7 @@ import Image from "next/image";
 import { buttonVariants } from "../ui/button";
 import { Card } from "../ui/card";
 import { cn } from "../ui/cn";
-import {
-  Cluster,
-  PageIntro,
-  ResponsiveGrid,
-  Section,
-  Stack,
-  SurfacePanel,
-} from "../ui/primitives";
+import { Cluster, ResponsiveGrid, Section, Stack } from "../ui/primitives";
 import {
   getOfferLeadSlotId,
   getOfferNextAvailableLabel,
@@ -82,381 +75,409 @@ export default function HeroSection({
   const featuredEvents = featuredMatches.slice(0, 4);
 
   return (
-    <Stack gap="xl" className="pb-4 sm:pb-6">
+    <Stack gap="xl" className="pb-6 sm:pb-8">
+      {/* ── Main hero card ──────────────────────────── */}
       <Section size="md" className="pb-0">
-        <SurfacePanel className="relative overflow-hidden p-5 sm:p-6 lg:p-8">
-          <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(125,211,252,0.18),transparent_35%),radial-gradient(circle_at_92%_18%,rgba(52,211,153,0.12),transparent_24%)]" />
-          <div className="pointer-events-none absolute -right-10 top-8 h-48 w-48 rounded-full bg-[rgba(125,211,252,0.12)] blur-3xl" />
-          <div className="pointer-events-none absolute -bottom-20 left-10 h-52 w-52 rounded-full bg-[rgba(52,211,153,0.12)] blur-3xl" />
-          <HeroFieldMarkings className="pointer-events-none absolute right-[8%] top-1/2 hidden w-[min(42%,320px)] -translate-y-1/2 opacity-[0.14] lg:block" />
+        <div className="surface-card relative overflow-hidden">
+          {/* Background atmosphere */}
+          <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_60%_50%_at_8%_0%,rgba(74,222,128,0.14),transparent),radial-gradient(ellipse_40%_40%_at_92%_8%,rgba(56,189,248,0.09),transparent),radial-gradient(ellipse_35%_45%_at_50%_100%,rgba(74,222,128,0.05),transparent)]" />
 
-          <div className="relative space-y-10">
-            <div className="grid items-center gap-10 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.35fr)_minmax(0,1fr)]">
-              <HeroVisualColumn
-                align="end"
-                className="hidden lg:flex"
-                tiles={[
-                  { label: "Near you", accent: "violet", icon: <IconMapPin className="h-9 w-9" /> },
-                  { label: "Recurring slots", accent: "rose", icon: <IconCalendar className="h-9 w-9" /> },
-                ]}
-              />
+          {/* Subtle pitch-lines watermark */}
+          <FieldWatermark className="pointer-events-none absolute right-0 top-0 h-full w-[46%] opacity-[0.055] text-[var(--color-brand)]" />
 
-              <PageIntro
-                kicker="Meda football"
-                title={<>Better pickup football — pitches, people, and payments in one place.</>}
-                description="Reserve pitch slots when you already have a squad, or browse one-off matches when you want to join a hosted game. Transparent ETB pricing either way."
-                actions={
-                  <>
-                    <Link
-                      href="/play?mode=slots"
-                      className={cn(buttonVariants("primary", "lg"), "rounded-full px-6")}
-                    >
-                      Book a slot
-                    </Link>
-                    <Link href="/play?mode=events" className={cn(buttonVariants("secondary", "lg"), "rounded-full px-6")}>
-                      Find a match
-                    </Link>
-                    <Link href="/host" className={cn(buttonVariants("secondary", "lg"), "rounded-full px-6")}>
-                      Host
-                    </Link>
-                  </>
-                }
-                meta={
-                  <>
-                    <StatPill
-                      label="Open slots"
-                      value={openSlotCount > 0 ? String(openSlotCount) : "—"}
-                    />
-                    <StatPill
-                      label="Matches"
-                      value={totalUpcoming > 0 ? String(totalUpcoming) : "—"}
-                    />
-                    <StatPill
-                      label="Cities"
-                      value={topCities.length > 0 ? String(topCities.length) : "—"}
-                    />
-                  </>
-                }
-              />
-
-              <HeroVisualColumn
-                align="start"
-                className="hidden lg:flex"
-                tiles={[
-                  { label: "Fair pricing", accent: "amber", icon: <IconCoins className="h-9 w-9" /> },
-                  { label: "Squads & groups", accent: "sky", icon: <IconUsers className="h-9 w-9" /> },
-                ]}
-              />
+          <div className="relative px-5 pb-8 pt-7 sm:px-7 sm:pb-10 sm:pt-9 lg:px-10 lg:pb-12 lg:pt-11">
+            {/* Kicker + stat pills */}
+            <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
+              <p className="heading-kicker">Meda football</p>
+              <div className="flex flex-wrap items-center gap-2">
+                <StatPill
+                  label="Open slots"
+                  value={openSlotCount > 0 ? String(openSlotCount) : "—"}
+                />
+                <StatPill
+                  label="Matches"
+                  value={totalUpcoming > 0 ? String(totalUpcoming) : "—"}
+                />
+                <StatPill
+                  label="Cities"
+                  value={topCities.length > 0 ? String(topCities.length) : "—"}
+                />
+              </div>
             </div>
 
-            <div className="grid grid-cols-2 gap-3 sm:grid-cols-4 lg:hidden">
-              <HeroVisualTile label="Near you" accent="violet" icon={<IconMapPin className="h-8 w-8" />} />
-              <HeroVisualTile label="Slots" accent="rose" icon={<IconCalendar className="h-8 w-8" />} />
-              <HeroVisualTile label="Pricing" accent="amber" icon={<IconCoins className="h-8 w-8" />} />
-              <HeroVisualTile label="Groups" accent="sky" icon={<IconUsers className="h-8 w-8" />} />
+            {/* Headline */}
+            <div className="max-w-3xl">
+              <h1 className="text-balance font-black tracking-[-0.06em] text-[var(--color-text-primary)] leading-[0.9] text-[clamp(2.8rem,7.5vw,5.5rem)]">
+                Better pickup{" "}
+                <span className="gradient-text">football.</span>
+              </h1>
+              <p className="mt-5 max-w-xl text-[clamp(0.95rem,1.5vw,1.08rem)] leading-[1.72] text-[var(--color-text-secondary)]">
+                Reserve pitch slots when you already have a squad, or browse organized matches
+                when you want to join a hosted game. Transparent ETB pricing, real-time availability.
+              </p>
             </div>
 
-            <div className="space-y-10">
-              <div>
-                <p className="heading-kicker text-(--color-brand)">Pitch bookings</p>
-                <div className="mt-2 flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
-                  <div className="max-w-2xl space-y-2">
-                    <h2 className="section-title text-balance">Got a full group? Pick a pitch.</h2>
-                    <p className="text-base leading-relaxed text-(--color-text-secondary)">
-                      Hey — do you have a full squad and want to lock in a field? Browse open slot windows,
-                      choose a time that fits, and book the pitch in ETB. That&apos;s the main path most teams
-                      use on Meda.
-                    </p>
-                  </div>
-                  <Link
-                    href="/play?mode=slots"
-                    className="shrink-0 text-sm font-semibold text-(--color-brand) transition hover:text-(--color-text-primary)"
-                  >
-                    See all slots
-                  </Link>
+            {/* CTAs */}
+            <Cluster gap="sm" className="mt-7">
+              <Link
+                href="/play?mode=slots"
+                className={cn(buttonVariants("primary", "lg"), "rounded-full px-7")}
+              >
+                Book a slot
+              </Link>
+              <Link
+                href="/play?mode=events"
+                className={cn(buttonVariants("secondary", "lg"), "rounded-full px-7")}
+              >
+                Find a match
+              </Link>
+              <Link
+                href="/host"
+                className={cn(buttonVariants("ghost", "lg"), "rounded-full px-7")}
+              >
+                Host a pitch
+              </Link>
+            </Cluster>
+
+            {/* ── Pitch Slots ──────────────────────────── */}
+            <div className="mt-10 lg:mt-12">
+              <div className="soft-divider mb-8" />
+
+              <div className="flex items-end justify-between gap-4 mb-5">
+                <div>
+                  <p className="heading-kicker mb-1">Pitch bookings</p>
+                  <h2 className="section-title text-balance">Got a full group? Pick a pitch.</h2>
                 </div>
-                {featuredSlotOffers.length > 0 ? (
-                  <div className="mt-6">
-                    <ResponsiveGrid cols="three" gap="md">
-                      {featuredSlotOffers.map((offer) => (
-                        <FeatureSlotCard key={offer.key} offer={offer} />
-                      ))}
-                    </ResponsiveGrid>
-                  </div>
-                ) : (
-                  <div className="mt-6">
-                    <EmptySlotsVisual />
-                  </div>
-                )}
+                <Link
+                  href="/play?mode=slots"
+                  className="shrink-0 flex items-center gap-1 text-sm font-semibold text-[var(--color-brand)] hover:text-[var(--color-text-primary)] transition"
+                >
+                  See all
+                  <ChevronRightIcon className="h-4 w-4" />
+                </Link>
               </div>
 
-              <div className="border-t border-(--color-border-strong) pt-10">
-                <p className="heading-kicker text-(--color-text-muted)">One-off matches</p>
-                <div className="mt-2 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
-                  <div className="max-w-xl space-y-1">
-                    <h3 className="text-xl font-semibold tracking-tight text-(--color-text-primary) sm:text-2xl">
-                      Discover an organized match
-                    </h3>
-                    <p className="text-sm text-(--color-text-secondary)">
-                      Prefer a hosted pickup or tournament-style event? Explore one-off matches here.
-                    </p>
-                  </div>
-                  <Link
-                    href="/play?mode=events"
-                    className="shrink-0 text-sm font-semibold text-(--color-text-secondary) transition hover:text-(--color-brand)"
-                  >
-                    See all matches
-                  </Link>
+              {featuredSlotOffers.length > 0 ? (
+                <ResponsiveGrid cols="three" gap="md">
+                  {featuredSlotOffers.map((offer) => (
+                    <FeatureSlotCard key={offer.key} offer={offer} />
+                  ))}
+                </ResponsiveGrid>
+              ) : (
+                <EmptySlotsVisual />
+              )}
+            </div>
+
+            {/* ── One-off Matches ──────────────────────── */}
+            <div className="mt-10 lg:mt-12">
+              <div className="soft-divider mb-8" />
+
+              <div className="flex items-end justify-between gap-4 mb-5">
+                <div>
+                  <p className="heading-kicker text-[var(--color-brand-alt)] mb-1">One-off matches</p>
+                  <h3 className="section-title">Discover an organized match</h3>
                 </div>
-                {featuredEvents.length > 0 ? (
-                  <div className="mt-6">
-                    <ResponsiveGrid cols="two" gap="md">
-                      {featuredEvents.map((match) => (
-                        <FeatureMatchCard key={match.eventId} match={match} />
-                      ))}
-                    </ResponsiveGrid>
-                  </div>
-                ) : (
-                  <div className="mt-6">
-                    <EmptyMatchesVisual compact />
-                  </div>
-                )}
+                <Link
+                  href="/play?mode=events"
+                  className="shrink-0 flex items-center gap-1 text-sm font-semibold text-[var(--color-text-secondary)] hover:text-[var(--color-brand)] transition"
+                >
+                  See all
+                  <ChevronRightIcon className="h-4 w-4" />
+                </Link>
               </div>
+
+              {featuredEvents.length > 0 ? (
+                <ResponsiveGrid cols="two" gap="md">
+                  {featuredEvents.map((match) => (
+                    <FeatureMatchCard key={match.eventId} match={match} />
+                  ))}
+                </ResponsiveGrid>
+              ) : (
+                <EmptyMatchesVisual />
+              )}
             </div>
           </div>
-        </SurfacePanel>
+        </div>
       </Section>
 
-      <Section size="md" className="pt-0">
-        <SurfacePanel>
-          <div className="grid gap-6 xl:grid-cols-2">
-            <div>
-              <p className="heading-kicker">Browse by category</p>
-              <h2 className="section-title mt-1">What kind of football?</h2>
+      {/* ── Browse by category & city ────────────────── */}
+      <Section size="sm" className="pt-0">
+        <div className="surface-card overflow-hidden">
+          <div className="grid gap-0 lg:grid-cols-2">
+            {/* Categories */}
+            <div className="p-5 sm:p-7 lg:p-8">
+              <p className="heading-kicker mb-1">Browse by category</p>
+              <h2 className="section-title mb-4">What kind of game?</h2>
               {topCategories.length > 0 ? (
-                <div className="mt-4 flex flex-wrap gap-2">
+                <div className="flex flex-wrap gap-2">
                   {topCategories.map((category) => (
                     <Link
                       key={category.name}
                       href={`/play?mode=events&search=${encodeURIComponent(category.name)}`}
-                      className="rounded-full border border-(--color-border-strong) bg-(--color-control-bg) px-4 py-2 text-sm font-medium text-(--color-text-secondary) transition hover:border-[rgba(125,211,252,0.3)] hover:text-(--color-text-primary)"
+                      className="group inline-flex items-center gap-1.5 rounded-full border border-[var(--color-border-strong)] bg-[var(--color-control-bg)] px-4 py-2 text-sm font-medium text-[var(--color-text-secondary)] transition hover:border-[rgba(74,222,128,0.4)] hover:bg-[rgba(74,222,128,0.08)] hover:text-[var(--color-text-primary)]"
                     >
-                      {category.name} ({category.upcomingCount})
+                      {category.name}
+                      <span className="rounded-full bg-[var(--color-control-bg-hover)] px-1.5 py-0.5 text-[0.65rem] font-bold text-[var(--color-text-muted)] group-hover:text-[var(--color-brand)]">
+                        {category.upcomingCount}
+                      </span>
                     </Link>
                   ))}
                 </div>
               ) : (
-                <p className="mt-4 text-sm text-(--color-text-secondary)">Categories will appear as hosts publish events.</p>
+                <p className="text-sm text-[var(--color-text-muted)]">
+                  Categories will appear as hosts publish events.
+                </p>
               )}
             </div>
-            <div>
-              <p className="heading-kicker">Cities</p>
-              <h2 className="section-title mt-1">Where the action is</h2>
+
+            {/* Cities */}
+            <div className="border-t border-[var(--color-border)] p-5 sm:p-7 lg:border-l lg:border-t-0 lg:p-8">
+              <p className="heading-kicker mb-1">Cities</p>
+              <h2 className="section-title mb-4">Where the action is</h2>
               {topCities.length > 0 ? (
-                <div className="mt-4 flex flex-wrap gap-2">
+                <div className="flex flex-wrap gap-2">
                   {topCities.map((city) => (
                     <Link
                       key={city.name}
                       href={`/play?mode=events&search=${encodeURIComponent(city.name)}`}
-                      className="rounded-full border border-(--color-border-strong) bg-(--color-control-bg) px-4 py-2 text-sm font-medium text-(--color-text-secondary) transition hover:border-[rgba(125,211,252,0.3)] hover:text-(--color-text-primary)"
+                      className="group inline-flex items-center gap-1.5 rounded-full border border-[var(--color-border-strong)] bg-[var(--color-control-bg)] px-4 py-2 text-sm font-medium text-[var(--color-text-secondary)] transition hover:border-[rgba(125,211,252,0.38)] hover:bg-[rgba(125,211,252,0.08)] hover:text-[var(--color-text-primary)]"
                     >
-                      {city.name} ({city.upcomingCount})
+                      {city.name}
+                      <span className="rounded-full bg-[var(--color-control-bg-hover)] px-1.5 py-0.5 text-[0.65rem] font-bold text-[var(--color-text-muted)] group-hover:text-[var(--color-brand-alt)]">
+                        {city.upcomingCount}
+                      </span>
                     </Link>
                   ))}
                 </div>
               ) : (
-                <p className="mt-4 text-sm text-(--color-text-secondary)">Cities will appear as local hosts publish.</p>
+                <p className="text-sm text-[var(--color-text-muted)]">
+                  Cities will appear as local hosts publish.
+                </p>
               )}
             </div>
           </div>
-        </SurfacePanel>
+        </div>
       </Section>
 
+      {/* ── Bottom CTA banner ────────────────────────── */}
       <Section size="sm" className="pt-0">
-        <SurfacePanel className="relative overflow-hidden">
-          <div
-            aria-hidden
-            className="pointer-events-none absolute -right-8 bottom-0 top-0 w-1/2 max-w-md opacity-[0.12]"
-          >
-            <HeroFieldMarkings className="h-full w-full" />
-          </div>
-          <div className="relative flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="surface-card relative overflow-hidden">
+          <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_55%_80%_at_0%_50%,rgba(74,222,128,0.1),transparent),radial-gradient(ellipse_35%_60%_at_100%_50%,rgba(56,189,248,0.08),transparent)]" />
+          <FieldWatermark className="pointer-events-none absolute -right-10 bottom-0 top-0 w-1/2 max-w-xs opacity-[0.06] text-[var(--color-brand)]" />
+
+          <div className="relative flex flex-col gap-5 p-5 sm:flex-row sm:items-center sm:justify-between sm:gap-6 sm:p-7 lg:p-8">
             <div className="flex items-center gap-4">
-              <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl border border-(--color-border-strong) bg-[rgba(125,211,252,0.1)] text-(--color-brand)">
-                <IconSpark className="h-8 w-8" />
+              <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl border border-[rgba(74,222,128,0.3)] bg-[rgba(74,222,128,0.12)] text-[var(--color-brand)]">
+                <BoltIcon className="h-7 w-7" />
               </div>
               <div>
-                <h2 className="section-title text-balance">Ready when you are</h2>
-                <p className="mt-1 text-sm text-(--color-text-secondary)">
-                  Book slots with your crew or browse matches — then open Host when you run a pitch.
+                <h2 className="text-xl font-bold tracking-[-0.04em] text-[var(--color-text-primary)]">
+                  Ready when you are
+                </h2>
+                <p className="mt-0.5 text-sm text-[var(--color-text-secondary)]">
+                  Book a slot with your crew or browse matches — then open Host when you run a pitch.
                 </p>
               </div>
             </div>
-            <Cluster gap="sm">
+
+            <Cluster gap="sm" className="shrink-0">
               <Link
                 href="/play?mode=slots"
-                className={cn(buttonVariants("primary", "lg"), "rounded-full px-6")}
+                className={cn(buttonVariants("primary", "md"), "rounded-full px-6")}
               >
                 Book slots
               </Link>
               <Link
                 href="/play?mode=events"
-                className={cn(buttonVariants("secondary", "lg"), "rounded-full px-6")}
+                className={cn(buttonVariants("secondary", "md"), "rounded-full px-6")}
               >
                 Matches
               </Link>
-              <Link href="/host" className={cn(buttonVariants("secondary", "lg"), "rounded-full px-6")}>
+              <Link
+                href="/host"
+                className={cn(buttonVariants("ghost", "md"), "rounded-full px-6")}
+              >
                 Host
               </Link>
             </Cluster>
           </div>
-        </SurfacePanel>
+        </div>
       </Section>
     </Stack>
   );
 }
 
-const visualBlob: Record<"violet" | "rose" | "amber" | "sky", string> = {
-  violet: "bg-violet-500/35",
-  rose: "bg-rose-500/35",
-  amber: "bg-amber-400/30",
-  sky: "bg-sky-400/30",
-};
+/* ── Sub-components ────────────────────────────────────── */
 
-function HeroVisualTile({
-  label,
-  accent,
-  icon,
-  className,
-}: {
-  label: string;
-  accent: keyof typeof visualBlob;
-  icon: ReactNode;
-  className?: string;
-}) {
+function StatPill({ label, value }: { label: string; value: string }) {
   return (
-    <div className={cn("relative isolate w-full max-w-[200px]", className)}>
-      <div
-        aria-hidden
-        className={cn(
-          "absolute -inset-4 -z-10 rounded-[55%_45%_52%_48%/48%_46%_54%_52%] opacity-80 blur-2xl",
-          visualBlob[accent],
-        )}
-      />
-      <Card className="flex flex-col items-center gap-3 rounded-3xl border-(--color-border-strong) bg-[rgba(7,17,26,0.78)] px-4 py-5 text-center shadow-lg backdrop-blur-sm">
-        <div className="text-(--color-text-primary) [&_svg]:opacity-90">{icon}</div>
-        <p className="text-xs font-bold uppercase tracking-[0.16em] text-(--color-text-secondary)">
-          {label}
-        </p>
-      </Card>
-    </div>
+    <span className="inline-flex items-center gap-2 rounded-full border border-[var(--color-border-strong)] bg-[var(--color-control-bg)] px-3 py-1.5 text-xs">
+      <span className="text-[var(--color-text-muted)]">{label}</span>
+      <span className="font-bold text-[var(--color-text-primary)]">{value}</span>
+    </span>
   );
 }
 
-function HeroVisualColumn({
-  tiles,
-  align,
-  className,
-}: {
-  tiles: Array<{ label: string; accent: keyof typeof visualBlob; icon: ReactNode }>;
-  align: "start" | "end";
-  className?: string;
-}) {
-  return (
-    <div
-      className={cn(
-        "flex flex-col gap-5",
-        align === "end" ? "items-end" : "items-start",
-        className,
-      )}
-    >
-      {tiles.map((tile) => (
-        <HeroVisualTile key={tile.label} {...tile} />
-      ))}
-    </div>
+function FeatureSlotCard({ offer }: { offer: LandingSlotOffer }) {
+  const leadId = getOfferLeadSlotId({ slots: offer.slots });
+  const href = leadId ? `/play/slots/${leadId}` : "/play?mode=slots";
+  const nextLabel = getOfferNextAvailableLabel({ slots: offer.slots });
+  const priceLabel = getOfferPriceLabel(offer);
+  const perPersonLabel = getOfferPerPersonPriceLabel(offer);
+  const sortedSlots = [...offer.slots].sort(
+    (a, b) => new Date(a.startsAt).getTime() - new Date(b.startsAt).getTime(),
   );
-}
+  const nextSlot = sortedSlots[0];
+  const imageSrc = offer.pitchImageUrl?.trim() || null;
 
-/** Stylized half-pitch + nodes — decorative only */
-function HeroFieldMarkings({ className }: { className?: string }) {
   return (
-    <svg
-      className={className}
-      viewBox="0 0 200 240"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-      aria-hidden
-    >
-      <path
-        d="M20 20h160v200H20V20z"
-        stroke="currentColor"
-        strokeWidth="1.2"
-        className="text-(--color-brand)"
-      />
-      <line
-        x1="100"
-        y1="20"
-        x2="100"
-        y2="220"
-        stroke="currentColor"
-        strokeWidth="1"
-        strokeDasharray="4 6"
-        className="text-(--color-brand)"
-        opacity="0.5"
-      />
-      <circle cx="100" cy="120" r="28" stroke="currentColor" strokeWidth="1" className="text-(--color-brand)" />
-      <circle cx="100" cy="120" r="3" fill="currentColor" className="text-(--color-brand-alt)" />
-      <circle cx="48" cy="72" r="6" fill="rgba(125,211,252,0.35)" />
-      <circle cx="152" cy="168" r="8" fill="rgba(52,211,153,0.3)" />
-      <path
-        d="M44 180 Q100 140 156 60"
-        stroke="currentColor"
-        strokeWidth="0.8"
-        strokeDasharray="3 5"
-        className="text-(--color-text-muted)"
-        opacity="0.4"
-      />
-    </svg>
-  );
-}
-
-function EmptyMatchesVisual({ compact = false }: { compact?: boolean }) {
-  return (
-    <Card className="relative overflow-hidden border-(--color-border-strong)">
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_80%_60%_at_70%_40%,rgba(125,211,252,0.12),transparent),radial-gradient(circle_at_15%_80%,rgba(52,211,153,0.1),transparent)]" />
-      <div
-        className={cn(
-          "relative grid gap-8 sm:grid-cols-[1fr_auto] sm:items-center",
-          compact ? "p-5 sm:p-6" : "p-6 sm:p-10",
-        )}
-      >
-        {!compact ? (
-          <div className="flex justify-center sm:justify-start">
-            <div className="relative w-full max-w-[280px]">
-              <div
-                aria-hidden
-                className="absolute -inset-6 rounded-[50%_45%_48%_52%/42%_58%_48%_52%] bg-violet-500/20 blur-3xl"
-              />
-              <EmptyPitchIllustration className="relative mx-auto w-full text-(--color-brand)" />
-            </div>
-          </div>
-        ) : null}
-        <div
-          className={cn(
-            "space-y-5 text-center sm:text-left",
-            compact ? "sm:max-w-lg" : "sm:max-w-xs",
+    <Link href={href} className="group block h-full">
+      <Card className="flex h-full flex-col overflow-hidden transition-all duration-200 hover:-translate-y-1 hover:shadow-[0_20px_56px_rgba(1,5,14,0.5)]">
+        {/* Image */}
+        <div className="relative aspect-[16/10] overflow-hidden bg-[var(--color-surface-3)]">
+          {imageSrc ? (
+            <Image
+              src={imageSrc}
+              alt={offer.pitchName}
+              fill
+              className="object-cover transition-transform duration-500 group-hover:scale-105"
+              sizes="(max-width: 768px) 100vw, (max-width: 1280px) 50vw, 33vw"
+            />
+          ) : (
+            <div className="absolute inset-0 bg-[radial-gradient(circle_at_20%_20%,rgba(74,222,128,0.22),transparent_40%),radial-gradient(circle_at_80%_80%,rgba(56,189,248,0.16),transparent_35%),linear-gradient(135deg,#102218,#0b1c2a)]" />
           )}
-        >
+          {/* Gradient overlay */}
+          <div className="absolute inset-0 bg-gradient-to-t from-[rgba(5,14,22,0.88)] via-[rgba(5,14,22,0.18)] to-transparent" />
+
+          {/* Category badge */}
+          <div className="absolute left-3 top-3">
+            <span className="rounded-full border border-[var(--color-border-strong)] bg-[rgba(5,14,22,0.8)] px-2.5 py-1 text-[0.68rem] font-bold uppercase tracking-[0.15em] text-[var(--color-text-primary)] backdrop-blur-sm">
+              {offer.categoryName}
+            </span>
+          </div>
+
+          {/* Price badges */}
+          <div className="absolute bottom-3 right-3 flex flex-col items-end gap-1.5">
+            <span className="rounded-full border border-[rgba(74,222,128,0.35)] bg-[rgba(74,222,128,0.18)] px-3 py-1 text-xs font-bold text-[var(--color-text-primary)] backdrop-blur-sm">
+              {priceLabel}
+            </span>
+            {perPersonLabel ? (
+              <span className="rounded-full border border-[var(--color-border)] bg-[rgba(5,14,22,0.85)] px-2.5 py-0.5 text-[0.65rem] font-medium text-[var(--color-text-secondary)] backdrop-blur-sm">
+                {perPersonLabel}
+              </span>
+            ) : null}
+          </div>
+
+          {offer.requiresParty ? (
+            <div className="absolute bottom-3 left-3">
+              <span className="rounded-full border border-[rgba(74,222,128,0.4)] bg-[rgba(5,14,22,0.82)] px-2.5 py-1 text-[0.65rem] font-bold uppercase tracking-[0.14em] text-[var(--color-brand)] backdrop-blur-sm">
+                Group booking
+              </span>
+            </div>
+          ) : null}
+        </div>
+
+        {/* Body */}
+        <div className="flex flex-1 flex-col gap-3 p-4 sm:p-5">
+          <div className="space-y-1.5">
+            <h3 className="line-clamp-2 text-[1.05rem] font-bold tracking-[-0.03em] text-[var(--color-text-primary)] leading-[1.25]">
+              {offer.pitchName}
+            </h3>
+            {nextLabel ? (
+              <p className="text-sm text-[var(--color-text-secondary)]">{nextLabel}</p>
+            ) : null}
+            <p className="line-clamp-1 text-xs text-[var(--color-text-muted)]">
+              {offer.addressLabel?.trim() || "Location on booking page"}
+            </p>
+          </div>
+
+          <div className="mt-auto flex items-center justify-between border-t border-[var(--color-border)] pt-3 text-xs">
+            <span className="font-semibold text-[var(--color-brand)]">
+              {nextSlot != null
+                ? `${nextSlot.remainingCapacity} spots (next window)`
+                : "Open slot"}
+            </span>
+            <span className="font-semibold text-[var(--color-text-muted)] transition group-hover:text-[var(--color-text-primary)]">
+              Book →
+            </span>
+          </div>
+        </div>
+      </Card>
+    </Link>
+  );
+}
+
+function FeatureMatchCard({ match }: { match: LandingMatch }) {
+  return (
+    <Link href={`/events/${match.eventId}`} className="group block h-full">
+      <Card className="flex h-full flex-col overflow-hidden transition-all duration-200 hover:-translate-y-1 hover:shadow-[0_20px_56px_rgba(1,5,14,0.5)]">
+        {/* Image */}
+        <div className="relative aspect-[16/9] overflow-hidden bg-[var(--color-surface-3)]">
+          {match.pictureUrl ? (
+            <Image
+              src={match.pictureUrl}
+              alt={match.title}
+              fill
+              className="object-cover transition-transform duration-500 group-hover:scale-105"
+              sizes="(max-width: 768px) 100vw, (max-width: 1280px) 50vw, 33vw"
+            />
+          ) : (
+            <div className="absolute inset-0 bg-[radial-gradient(circle_at_20%_20%,rgba(125,211,252,0.22),transparent_40%),radial-gradient(circle_at_80%_80%,rgba(74,222,128,0.16),transparent_35%),linear-gradient(135deg,#0e1e2e,#0b1a1e)]" />
+          )}
+          <div className="absolute inset-0 bg-gradient-to-t from-[rgba(5,14,22,0.88)] via-[rgba(5,14,22,0.18)] to-transparent" />
+
+          <div className="absolute left-3 top-3">
+            <span className="rounded-full border border-[rgba(74,222,128,0.35)] bg-[rgba(74,222,128,0.16)] px-2.5 py-1 text-[0.68rem] font-bold uppercase tracking-[0.15em] text-[var(--color-brand)] backdrop-blur-sm">
+              Upcoming
+            </span>
+          </div>
+
+          <div className="absolute bottom-3 right-3">
+            <span className="rounded-full border border-[rgba(125,211,252,0.32)] bg-[rgba(125,211,252,0.14)] px-3 py-1 text-xs font-bold text-[var(--color-text-primary)] backdrop-blur-sm">
+              {match.priceLabel}
+            </span>
+          </div>
+        </div>
+
+        {/* Body */}
+        <div className="flex flex-1 flex-col gap-3 p-4 sm:p-5">
+          <div className="space-y-1.5">
+            <h3 className="line-clamp-2 text-[1.05rem] font-bold tracking-[-0.03em] text-[var(--color-text-primary)] leading-[1.25]">
+              {match.title}
+            </h3>
+            <p className="text-sm text-[var(--color-text-secondary)]">{match.when}</p>
+            <p className="line-clamp-1 text-xs text-[var(--color-text-muted)]">
+              {match.locationLabel}
+            </p>
+          </div>
+
+          <div className="mt-auto flex items-center justify-between border-t border-[var(--color-border)] pt-3 text-xs">
+            <span className="font-semibold text-[var(--color-brand-alt)]">
+              {match.spotsLeft != null
+                ? `${match.spotsLeft} spots left`
+                : `${match.attendeeCount} attending`}
+            </span>
+            <span className="font-semibold text-[var(--color-text-muted)] transition group-hover:text-[var(--color-text-primary)]">
+              View →
+            </span>
+          </div>
+        </div>
+      </Card>
+    </Link>
+  );
+}
+
+function EmptyMatchesVisual() {
+  return (
+    <Card className="relative overflow-hidden border-[var(--color-border)]">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_80%_60%_at_70%_40%,rgba(125,211,252,0.1),transparent),radial-gradient(circle_at_10%_80%,rgba(74,222,128,0.08),transparent)]" />
+      <div className="relative flex flex-col gap-5 p-6 sm:flex-row sm:items-center sm:p-8">
+        <div className="space-y-4 sm:max-w-md">
           <p className="heading-kicker">Matches</p>
-          <p
-            className={cn(
-              "font-semibold tracking-tight text-(--color-text-primary)",
-              compact ? "text-base" : "text-lg",
-            )}
-          >
+          <p className="text-base font-semibold tracking-tight text-[var(--color-text-primary)]">
             No matches listed yet — check back soon or book a pitch slot with your group.
           </p>
-          <Cluster gap="sm" className="justify-center sm:justify-start">
+          <Cluster gap="sm">
             <Link
               href="/play?mode=events"
               className={cn(buttonVariants("primary", "md"), "rounded-full px-5")}
@@ -478,31 +499,25 @@ function EmptyMatchesVisual({ compact = false }: { compact?: boolean }) {
 
 function EmptySlotsVisual() {
   return (
-    <Card className="relative overflow-hidden border-(--color-border-strong)">
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_75%_55%_at_30%_35%,rgba(52,211,153,0.14),transparent),radial-gradient(circle_at_90%_70%,rgba(125,211,252,0.1),transparent)]" />
-      <div className="relative grid gap-8 p-6 sm:grid-cols-[1fr_auto] sm:items-center sm:p-10">
-        <div className="flex justify-center sm:justify-start">
-          <div className="relative w-full max-w-[280px]">
-            <div
-              aria-hidden
-              className="absolute -inset-6 rounded-[50%_45%_48%_52%/42%_58%_48%_52%] bg-emerald-500/15 blur-3xl"
-            />
-            <EmptyPitchIllustration className="relative mx-auto w-full text-(--color-brand)" />
-          </div>
-        </div>
-        <div className="space-y-5 text-center sm:max-w-xs sm:text-left">
+    <Card className="relative overflow-hidden border-[var(--color-border)]">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_75%_55%_at_30%_35%,rgba(74,222,128,0.1),transparent),radial-gradient(circle_at_90%_70%,rgba(125,211,252,0.08),transparent)]" />
+      <div className="relative flex flex-col gap-5 p-6 sm:flex-row sm:items-center sm:p-8">
+        <div className="space-y-4 sm:max-w-md">
           <p className="heading-kicker">Pitch slots</p>
-          <p className="text-lg font-semibold tracking-tight text-(--color-text-primary)">
+          <p className="text-base font-semibold tracking-tight text-[var(--color-text-primary)]">
             No open slots right now — hosts add new windows often. Try again shortly or list your own pitch.
           </p>
-          <Cluster gap="sm" className="justify-center sm:justify-start">
+          <Cluster gap="sm">
             <Link
               href="/play?mode=slots"
               className={cn(buttonVariants("primary", "md"), "rounded-full px-5")}
             >
               Open slot finder
             </Link>
-            <Link href="/host" className={cn(buttonVariants("secondary", "md"), "rounded-full px-5")}>
+            <Link
+              href="/host"
+              className={cn(buttonVariants("secondary", "md"), "rounded-full px-5")}
+            >
               Host a pitch
             </Link>
           </Cluster>
@@ -512,217 +527,63 @@ function EmptySlotsVisual() {
   );
 }
 
-function EmptyPitchIllustration({ className }: { className?: string }) {
+/* ── Icons ─────────────────────────────────────────────── */
+
+function FieldWatermark({ className }: { className?: string }) {
   return (
     <svg
       className={className}
-      viewBox="0 0 320 220"
+      viewBox="0 0 240 320"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       aria-hidden
     >
-      <ellipse cx="160" cy="118" rx="118" ry="72" stroke="currentColor" strokeWidth="1.5" opacity="0.35" />
-      <circle cx="160" cy="118" r="22" stroke="currentColor" strokeWidth="1.2" opacity="0.5" />
-      <circle cx="160" cy="118" r="3" fill="currentColor" opacity="0.7" />
-      <rect
-        x="52"
-        y="48"
-        width="216"
-        height="140"
-        rx="12"
-        stroke="currentColor"
-        strokeWidth="1.2"
-        opacity="0.25"
-      />
-      <path d="M88 118h144" stroke="currentColor" strokeWidth="1" strokeDasharray="5 8" opacity="0.3" />
-      <circle cx="92" cy="78" r="10" fill="rgba(125,211,252,0.25)" stroke="currentColor" strokeWidth="0.8" />
-      <circle cx="228" cy="158" r="12" fill="rgba(52,211,153,0.22)" stroke="currentColor" strokeWidth="0.8" />
-      <circle cx="248" cy="72" r="8" fill="rgba(251,191,36,0.2)" />
-      <path
-        d="M96 168c32-24 64-36 128-20"
-        stroke="currentColor"
-        strokeWidth="1"
-        strokeLinecap="round"
-        strokeDasharray="4 7"
-        opacity="0.35"
-      />
+      {/* Outer pitch rectangle */}
+      <rect x="20" y="20" width="200" height="280" rx="4" stroke="currentColor" strokeWidth="1.5" />
+      {/* Centre line */}
+      <line x1="20" y1="160" x2="220" y2="160" stroke="currentColor" strokeWidth="1" strokeDasharray="5 7" opacity="0.6" />
+      {/* Centre circle */}
+      <circle cx="120" cy="160" r="36" stroke="currentColor" strokeWidth="1" opacity="0.8" />
+      {/* Centre dot */}
+      <circle cx="120" cy="160" r="3.5" fill="currentColor" opacity="0.9" />
+      {/* Top goal area */}
+      <rect x="70" y="20" width="100" height="42" stroke="currentColor" strokeWidth="1" opacity="0.7" />
+      {/* Bottom goal area */}
+      <rect x="70" y="258" width="100" height="42" stroke="currentColor" strokeWidth="1" opacity="0.7" />
+      {/* Top penalty spot */}
+      <circle cx="120" cy="78" r="2.5" fill="currentColor" opacity="0.6" />
+      {/* Bottom penalty spot */}
+      <circle cx="120" cy="242" r="2.5" fill="currentColor" opacity="0.6" />
+      {/* Corner arcs */}
+      <path d="M20 32 A12 12 0 0 1 32 20" stroke="currentColor" strokeWidth="1" opacity="0.5" />
+      <path d="M208 20 A12 12 0 0 1 220 32" stroke="currentColor" strokeWidth="1" opacity="0.5" />
+      <path d="M20 288 A12 12 0 0 0 32 300" stroke="currentColor" strokeWidth="1" opacity="0.5" />
+      <path d="M208 300 A12 12 0 0 0 220 288" stroke="currentColor" strokeWidth="1" opacity="0.5" />
     </svg>
   );
 }
 
-function IconMapPin({ className }: { className?: string }) {
-  return (
-    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" aria-hidden>
-      <path d="M12 21s7-4.35 7-11a7 7 0 10-14 0c0 6.65 7 11 7 11z" strokeLinecap="round" strokeLinejoin="round" />
-      <circle cx="12" cy="10" r="2.25" />
-    </svg>
-  );
-}
-
-function IconCalendar({ className }: { className?: string }) {
-  return (
-    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" aria-hidden>
-      <rect x="3.5" y="5" width="17" height="16" rx="2" />
-      <path d="M3.5 9.5h17M8 3v4M16 3v4" strokeLinecap="round" />
-      <path d="M8 14h2M12 14h2M16 14h2M8 17h2" strokeLinecap="round" opacity="0.7" />
-    </svg>
-  );
-}
-
-function IconCoins({ className }: { className?: string }) {
-  return (
-    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" aria-hidden>
-      <ellipse cx="9" cy="7" rx="5" ry="3" />
-      <path d="M4 7v8c0 1.66 2.24 3 5 3s5-1.34 5-3V7" />
-      <path d="M14 10c2.76 0 5-1.34 5-3s-2.24-3-5-3" opacity="0.65" />
-      <path d="M19 7v6" strokeLinecap="round" opacity="0.65" />
-    </svg>
-  );
-}
-
-function IconUsers({ className }: { className?: string }) {
-  return (
-    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" aria-hidden>
-      <circle cx="9" cy="8" r="3" />
-      <path d="M3.5 20.5v-1c0-2.2 2.02-4 4.5-4h2c2.48 0 4.5 1.8 4.5 4v1" strokeLinecap="round" />
-      <circle cx="17" cy="9" r="2.5" opacity="0.85" />
-      <path d="M21 20.5v-0.5c0-1.6-1.34-2.9-3-3.2" strokeLinecap="round" opacity="0.85" />
-    </svg>
-  );
-}
-
-function IconSpark({ className }: { className?: string }) {
+function BoltIcon({ className }: { className?: string }) {
   return (
     <svg className={className} viewBox="0 0 24 24" fill="currentColor" aria-hidden>
-      <path d="M12 2l1.2 5.4L18 9l-4.8 1.6L12 16l-1.2-5.4L6 9l4.8-1.6L12 2zM19 14l.6 2.4L22 17l-2.4.6L19 20l-.6-2.4L16 17l2.4-.6L19 14zM5 15l.5 2L7 17.5l-1.5.5L5 20l-.5-2L3 17.5l1.5-.5L5 15z" />
+      <path d="M13 2L4.5 13.5H11L11 22L19.5 10.5H13L13 2Z" />
     </svg>
   );
 }
 
-function StatPill({ label, value }: { label: string; value: string }) {
+function ChevronRightIcon({ className }: { className?: string }) {
   return (
-    <span className="inline-flex items-center gap-2 rounded-full border border-(--color-border-strong) bg-white/6 px-3 py-1.5 text-sm text-(--color-text-secondary)">
-      <span className="text-(--color-text-secondary)">{label}</span>
-      <span className="font-semibold text-(--color-text-primary)">{value}</span>
-    </span>
-  );
-}
-
-function FeatureSlotCard({ offer }: { offer: LandingSlotOffer }) {
-  const leadId = getOfferLeadSlotId({ slots: offer.slots });
-  const href = leadId ? `/play/slots/${leadId}` : "/play?mode=slots";
-  const nextLabel = getOfferNextAvailableLabel({ slots: offer.slots });
-  const priceLabel = getOfferPriceLabel(offer);
-  const perPersonLabel = getOfferPerPersonPriceLabel(offer);
-  const sortedSlots = [...offer.slots].sort(
-    (a, b) => new Date(a.startsAt).getTime() - new Date(b.startsAt).getTime(),
-  );
-  const nextSlot = sortedSlots[0];
-  const imageSrc = offer.pitchImageUrl?.trim() || null;
-
-  return (
-    <Link href={href} className="group h-full">
-      <Card className="flex h-full flex-col overflow-hidden transition hover:-translate-y-0.5">
-        <div className="relative aspect-16/10 overflow-hidden">
-          {imageSrc ? (
-            <Image
-              src={imageSrc}
-              alt={offer.pitchName}
-              fill
-              className="object-cover transition duration-500 group-hover:scale-105"
-              sizes="(max-width: 768px) 100vw, (max-width: 1280px) 50vw, 33vw"
-            />
-          ) : (
-            <div className="absolute inset-0 bg-[radial-gradient(circle_at_18%_18%,rgba(52,211,153,0.2),transparent_30%),radial-gradient(circle_at_100%_0%,rgba(125,211,252,0.18),transparent_26%),linear-gradient(135deg,#102033,#0b1724)]" />
-          )}
-          <div className="absolute inset-0 bg-gradient-to-t from-[rgba(6,17,27,0.84)] via-[rgba(6,17,27,0.22)] to-transparent" />
-          <div className="absolute inset-x-3 bottom-3 flex items-end justify-between gap-3">
-            <span className="rounded-full border border-(--color-border-strong) bg-[rgba(7,17,26,0.78)] px-2.5 py-1 text-[0.72rem] font-semibold uppercase tracking-[0.16em] text-(--color-text-primary) backdrop-blur">
-              {offer.categoryName}
-            </span>
-            <div className="flex max-w-[min(100%,11rem)] flex-col items-end gap-1">
-              <span className="rounded-full border border-[rgba(52,211,153,0.28)] bg-[rgba(52,211,153,0.14)] px-3 py-1 text-xs font-semibold text-(--color-text-primary) backdrop-blur">
-                {priceLabel}
-              </span>
-              {perPersonLabel ? (
-                <span className="rounded-full border border-[rgba(125,211,252,0.22)] bg-[rgba(7,17,26,0.82)] px-2.5 py-0.5 text-[0.65rem] font-medium leading-tight text-(--color-text-secondary) backdrop-blur">
-                  {perPersonLabel}
-                </span>
-              ) : null}
-            </div>
-          </div>
-          {offer.requiresParty ? (
-            <div className="absolute left-3 top-3">
-              <span className="rounded-full border border-[rgba(125,211,252,0.35)] bg-[rgba(7,17,26,0.82)] px-2.5 py-1 text-[0.65rem] font-bold uppercase tracking-[0.14em] text-(--color-brand) backdrop-blur">
-                Group
-              </span>
-            </div>
-          ) : null}
-        </div>
-        <div className="flex flex-1 flex-col gap-3 p-4 sm:p-5">
-          <div className="space-y-2">
-            <h3 className="line-clamp-2 text-xl font-semibold tracking-[-0.03em] text-(--color-text-primary)">
-              {offer.pitchName}
-            </h3>
-            {nextLabel ? <p className="text-sm text-(--color-text-secondary)">{nextLabel}</p> : null}
-            <p className="line-clamp-1 text-sm text-(--color-text-muted)">
-              {offer.addressLabel?.trim() || "Location on booking page"}
-            </p>
-          </div>
-
-          <div className="mt-auto flex items-center justify-between pt-3 text-sm">
-            <span className="font-medium text-[#c9ffea]">
-              {nextSlot != null
-                ? `${nextSlot.remainingCapacity} spots left (next window)`
-                : "Open slot"}
-            </span>
-            <span className="text-(--color-text-muted) transition group-hover:text-(--color-text-primary)">
-              Book slot
-            </span>
-          </div>
-        </div>
-      </Card>
-    </Link>
-  );
-}
-
-function FeatureMatchCard({ match }: { match: LandingMatch }) {
-  return (
-    <Link href={`/events/${match.eventId}`} className="group h-full">
-      <Card className="flex h-full flex-col overflow-hidden transition hover:-translate-y-0.5">
-        <div className="relative aspect-16/10 overflow-hidden">
-          {match.pictureUrl ? (
-            <Image src={match.pictureUrl} alt={match.title} fill className="object-cover transition duration-500 group-hover:scale-105" sizes="(max-width: 768px) 100vw, (max-width: 1280px) 50vw, 33vw" />
-          ) : (
-            <div className="absolute inset-0 bg-[radial-gradient(circle_at_18%_18%,rgba(125,211,252,0.22),transparent_30%),radial-gradient(circle_at_100%_0%,rgba(52,211,153,0.18),transparent_26%),linear-gradient(135deg,#102033,#0b1724)]" />
-          )}
-          <div className="absolute inset-0 bg-gradient-to-t from-[rgba(6,17,27,0.84)] via-[rgba(6,17,27,0.22)] to-transparent" />
-          <div className="absolute inset-x-3 bottom-3 flex items-center justify-between gap-3">
-            <span className="rounded-full border border-(--color-border-strong) bg-[rgba(7,17,26,0.78)] px-2.5 py-1 text-[0.72rem] font-semibold uppercase tracking-[0.16em] text-(--color-text-primary) backdrop-blur">
-              Upcoming
-            </span>
-            <span className="rounded-full border border-[rgba(125,211,252,0.22)] bg-[rgba(125,211,252,0.16)] px-3 py-1 text-xs font-semibold text-(--color-text-primary) backdrop-blur">
-              {match.priceLabel}
-            </span>
-          </div>
-        </div>
-        <div className="flex flex-1 flex-col gap-3 p-4 sm:p-5">
-          <div className="space-y-2">
-            <h3 className="line-clamp-2 text-xl font-semibold tracking-[-0.03em] text-(--color-text-primary)">
-              {match.title}
-            </h3>
-            <p className="text-sm text-(--color-text-secondary)">{match.when}</p>
-            <p className="line-clamp-1 text-sm text-(--color-text-muted)">{match.locationLabel}</p>
-          </div>
-
-          <div className="mt-auto flex items-center justify-between pt-3 text-sm">
-            <span className="font-medium text-[#c9ffea]">
-              {match.spotsLeft != null ? `${match.spotsLeft} spots left` : `${match.attendeeCount} attending`}
-            </span>
-            <span className="text-(--color-text-muted) transition group-hover:text-(--color-text-primary)">View match</span>
-          </div>
-        </div>
-      </Card>
-    </Link>
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <polyline points="9 18 15 12 9 6" />
+    </svg>
   );
 }

--- a/app/components/ui/app-page-header.tsx
+++ b/app/components/ui/app-page-header.tsx
@@ -25,16 +25,16 @@ export function AppPageHeader({
   return (
     <Card
       className={cn(
-        "relative overflow-hidden border-[rgba(125,211,252,0.18)] bg-[radial-gradient(circle_at_top_left,rgba(125,211,252,0.16),transparent_34%),radial-gradient(circle_at_88%_12%,rgba(52,211,153,0.12),transparent_28%),linear-gradient(145deg,#102033,#0b1724)] p-4 sm:p-6 lg:p-7",
+        "relative overflow-hidden border-[rgba(74,222,128,0.18)] bg-[radial-gradient(ellipse_55%_50%_at_5%_0%,rgba(74,222,128,0.13),transparent),radial-gradient(ellipse_35%_40%_at_90%_10%,rgba(56,189,248,0.09),transparent),linear-gradient(150deg,#0e2016,#0b1724)] p-4 sm:p-6 lg:p-7",
         className,
       )}
     >
-      <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(180deg,rgba(255,255,255,0.02),transparent_32%,rgba(0,0,0,0.12))]" />
+      <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(175deg,rgba(255,255,255,0.025),transparent_30%,rgba(0,0,0,0.1))]" />
       <div className="relative space-y-4 sm:space-y-5">
         <div className="space-y-2.5">
           {kicker ? <p className="heading-kicker">{kicker}</p> : null}
           <div className="max-w-4xl space-y-2.5">
-            <h1 className="text-balance text-[var(--text-h1)] font-semibold leading-[1.02] tracking-[-0.04em] text-[var(--color-text-primary)] sm:text-[var(--text-display)] sm:leading-[0.95]">
+            <h1 className="text-balance text-[var(--text-h1)] font-bold leading-[1.02] tracking-[-0.045em] text-[var(--color-text-primary)] sm:text-[var(--text-display)] sm:leading-[0.94]">
               {title}
             </h1>
             {description ? (

--- a/app/components/ui/badge.tsx
+++ b/app/components/ui/badge.tsx
@@ -1,34 +1,34 @@
 /**
- * Badge -- small status label with variants (default, accent, success).
+ * Badge -- small status label with variants (default, accent, success, warning, danger).
  */
 
 import type { HTMLAttributes } from "react";
 import { cn } from "./cn";
 
-type BadgeVariant = "default" | "accent" | "success";
+type BadgeVariant = "default" | "accent" | "success" | "warning" | "danger";
 
 const badgeVariantClasses: Record<BadgeVariant, string> = {
   default:
     "border border-[var(--color-border)] bg-[var(--color-control-bg)] text-[var(--color-text-secondary)]",
   accent:
-    "border border-[rgba(125,211,252,0.28)] bg-[var(--color-accent-soft)] text-[var(--color-text-primary)]",
+    "border border-[rgba(74,222,128,0.3)] bg-[var(--color-accent-soft)] text-[var(--color-text-primary)]",
   success:
-    "border border-[rgba(52,211,153,0.24)] bg-[var(--color-success-soft)] text-[var(--color-text-primary)]",
+    "border border-[rgba(74,222,128,0.3)] bg-[var(--color-success-soft)] text-[var(--color-brand)]",
+  warning:
+    "border border-[rgba(251,191,36,0.3)] bg-[rgba(251,191,36,0.1)] text-[var(--color-warning)]",
+  danger:
+    "border border-[rgba(251,113,133,0.3)] bg-[rgba(127,29,29,0.16)] text-[#fecdd3]",
 };
 
 type BadgeProps = HTMLAttributes<HTMLSpanElement> & {
   variant?: BadgeVariant;
 };
 
-export function Badge({
-  className,
-  variant = "default",
-  ...props
-}: BadgeProps) {
+export function Badge({ className, variant = "default", ...props }: BadgeProps) {
   return (
     <span
       className={cn(
-        "inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold tracking-[0.01em]",
+        "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold tracking-[0.01em]",
         badgeVariantClasses[variant],
         className,
       )}

--- a/app/components/ui/button.tsx
+++ b/app/components/ui/button.tsx
@@ -9,23 +9,23 @@ type ButtonVariant = "primary" | "secondary" | "ghost" | "danger";
 type ButtonSize = "sm" | "md" | "lg";
 
 export const buttonBaseClass =
-  "inline-flex items-center justify-center whitespace-nowrap rounded-[var(--radius-md)] border border-transparent font-semibold tracking-[-0.01em] transition duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg)] disabled:cursor-not-allowed disabled:opacity-50";
+  "inline-flex items-center justify-center whitespace-nowrap rounded-[var(--radius-md)] border border-transparent font-semibold tracking-[-0.012em] transition duration-160 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg)] disabled:cursor-not-allowed disabled:opacity-45 select-none";
 
 const variantClasses: Record<ButtonVariant, string> = {
   primary:
-    "bg-[linear-gradient(135deg,var(--color-brand)_0%,var(--color-brand-strong)_58%,#dff7ff_100%)] text-[var(--color-brand-text)] shadow-[0_18px_44px_rgba(56,189,248,0.24)] hover:-translate-y-0.5 hover:shadow-[0_22px_48px_rgba(56,189,248,0.28)]",
+    "bg-[linear-gradient(140deg,#4ade80_0%,#22c55e_55%,#16a34a_100%)] text-[var(--color-brand-text)] shadow-[0_12px_36px_rgba(34,197,94,0.32),inset_0_1px_0_rgba(255,255,255,0.2)] hover:-translate-y-0.5 hover:shadow-[0_16px_44px_rgba(34,197,94,0.4),inset_0_1px_0_rgba(255,255,255,0.2)] active:translate-y-0 active:shadow-[0_6px_20px_rgba(34,197,94,0.26)]",
   secondary:
-    "border-[var(--color-border-strong)] bg-[var(--color-control-bg)] text-[var(--color-text-primary)] shadow-[inset_0_1px_0_rgba(255,255,255,0.04)] hover:border-[rgba(125,211,252,0.46)] hover:bg-[var(--color-control-bg-hover)]",
+    "border-[var(--color-border-strong)] bg-[var(--color-control-bg)] text-[var(--color-text-primary)] shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] hover:border-[rgba(74,222,128,0.38)] hover:bg-[var(--color-control-bg-hover)] hover:text-[var(--color-text-primary)]",
   ghost:
     "text-[var(--color-text-secondary)] hover:bg-[var(--color-control-bg)] hover:text-[var(--color-text-primary)]",
   danger:
-    "border-[rgba(251,113,133,0.4)] bg-[rgba(127,29,29,0.18)] text-[#fecdd3] hover:bg-[rgba(153,27,27,0.28)] hover:border-[rgba(251,113,133,0.55)]",
+    "border-[rgba(251,113,133,0.36)] bg-[rgba(127,29,29,0.16)] text-[#fecdd3] hover:bg-[rgba(153,27,27,0.26)] hover:border-[rgba(251,113,133,0.52)]",
 };
 
 const sizeClasses: Record<ButtonSize, string> = {
-  sm: "h-9 px-3.5 text-sm",
-  md: "h-10 px-4 text-sm",
-  lg: "h-11 px-5 text-sm",
+  sm: "h-8  px-3.5 text-xs gap-1.5",
+  md: "h-10 px-4   text-sm gap-2",
+  lg: "h-11 px-5   text-sm gap-2",
 };
 
 export function buttonVariants(variant: ButtonVariant = "secondary", size: ButtonSize = "md") {

--- a/app/components/ui/empty-state.tsx
+++ b/app/components/ui/empty-state.tsx
@@ -42,17 +42,25 @@ export function EmptyState({
         <div className="text-[var(--color-text-muted)]">{icon}</div>
       ) : (
         <div
-          className="flex h-16 w-16 items-center justify-center rounded-full border border-[var(--color-border-strong)] bg-[rgba(125,211,252,0.08)] text-[var(--color-brand)]"
+          className="flex h-16 w-16 items-center justify-center rounded-2xl border border-[rgba(74,222,128,0.25)] bg-[rgba(74,222,128,0.08)] text-[var(--color-brand)]"
           aria-hidden
         >
-          <svg className="h-7 w-7" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+          <svg
+            className="h-7 w-7"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.6"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
             <circle cx="12" cy="12" r="10" />
             <path d="M8 15h8M9 9h.01M15 9h.01" />
           </svg>
         </div>
       )}
       <div className="max-w-md space-y-2">
-        <h3 className="text-xl font-semibold tracking-[-0.03em] text-[var(--color-text-primary)]">
+        <h3 className="text-xl font-bold tracking-[-0.035em] text-[var(--color-text-primary)]">
           {title}
         </h3>
         {description ? (

--- a/app/components/ui/input.tsx
+++ b/app/components/ui/input.tsx
@@ -6,7 +6,7 @@ import type { InputHTMLAttributes } from "react";
 import { cn } from "./cn";
 
 export const inputBaseClass =
-  "h-10 w-full rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-control-bg)] px-3.5 text-sm text-[var(--color-text-primary)] shadow-[inset_0_1px_0_rgba(255,255,255,0.03)] placeholder:text-[var(--color-text-muted)] focus-visible:border-[rgba(125,211,252,0.46)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)]";
+  "h-10 w-full rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-control-bg)] px-3.5 text-sm text-[var(--color-text-primary)] shadow-[inset_0_1px_0_rgba(255,255,255,0.03)] placeholder:text-[var(--color-text-muted)] focus-visible:border-[rgba(74,222,128,0.5)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)] transition";
 
 type InputProps = InputHTMLAttributes<HTMLInputElement>;
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -6,82 +6,110 @@
 :root {
   color-scheme: dark;
 
-  --background: #07111a;
+  --background: #060f18;
   --foreground: #eef6ff;
 
-  --color-bg: #07111a;
-  --color-bg-elevated: #091521;
-  --color-surface: rgba(10, 19, 30, 0.96);
-  --color-surface-2: rgba(12, 23, 36, 0.98);
-  --color-surface-3: rgba(16, 30, 46, 0.98);
-  --color-border: rgba(148, 163, 184, 0.28);
-  --color-border-strong: rgba(148, 163, 184, 0.46);
-  --color-text-primary: #f8fbff;
-  --color-text-secondary: #d7e4f2;
-  --color-text-muted: #afc2d4;
-  --color-brand: #7dd3fc;
-  --color-brand-strong: #38bdf8;
-  --color-brand-alt: #34d399;
-  --color-brand-text: #03111c;
-  --color-ring: rgba(125, 211, 252, 0.42);
-  --color-danger: #fb7185;
+  /* ── Surfaces ────────────────────────────────────── */
+  --color-bg:          #060f18;
+  --color-bg-elevated: #081422;
+  --color-surface:     rgba(8, 18, 28, 0.97);
+  --color-surface-2:   rgba(10, 21, 34, 0.98);
+  --color-surface-3:   rgba(14, 26, 42, 0.98);
+
+  /* ── Borders ─────────────────────────────────────── */
+  --color-border:        rgba(148, 163, 184, 0.22);
+  --color-border-strong: rgba(148, 163, 184, 0.38);
+
+  /* ── Text ────────────────────────────────────────── */
+  --color-text-primary:   #f4faff;
+  --color-text-secondary: #ccdde8;
+  --color-text-muted:     #8faab8;
+
+  /* ── Brand — pitch green ─────────────────────────── */
+  --color-brand:       #4ade80;
+  --color-brand-strong:#22c55e;
+  --color-brand-deep:  #16a34a;
+  --color-brand-text:  #012b14;   /* dark text on brand-colored surfaces */
+
+  /* ── Accent — sky blue (secondary) ──────────────── */
+  --color-brand-alt:   #7dd3fc;
+  --color-accent:      #38bdf8;
+
+  /* ── Status ──────────────────────────────────────── */
+  --color-danger:  #fb7185;
   --color-warning: #fbbf24;
-  --color-control-bg: rgba(255, 255, 255, 0.085);
-  --color-control-bg-hover: rgba(255, 255, 255, 0.12);
-  --color-accent-soft: rgba(125, 211, 252, 0.18);
-  --color-success-soft: rgba(52, 211, 153, 0.18);
-  --shadow-elevated: 0 28px 90px rgba(2, 6, 23, 0.44);
-  --shadow-card: 0 18px 42px rgba(2, 6, 23, 0.38);
-  --shadow-soft: 0 10px 22px rgba(2, 6, 23, 0.16);
 
+  /* ── Soft fills ──────────────────────────────────── */
+  --color-ring:            rgba(74, 222, 128, 0.45);
+  --color-accent-soft:     rgba(74, 222, 128, 0.13);
+  --color-accent-soft-alt: rgba(125, 211, 252, 0.12);
+  --color-success-soft:    rgba(74, 222, 128, 0.13);
+  --color-control-bg:      rgba(255, 255, 255, 0.07);
+  --color-control-bg-hover:rgba(255, 255, 255, 0.11);
+
+  /* ── Shadows ─────────────────────────────────────── */
+  --shadow-elevated: 0 28px 80px rgba(1, 5, 14, 0.52);
+  --shadow-card:     0 16px 48px rgba(1, 5, 14, 0.38);
+  --shadow-soft:     0 8px 24px  rgba(1, 5, 14, 0.18);
+  --shadow-brand:    0 16px 48px rgba(34, 197, 94, 0.22);
+
+  /* ── Backgrounds ─────────────────────────────────── */
   --body-bg:
-    radial-gradient(circle at top left, rgba(56, 189, 248, 0.05), transparent 24%),
-    radial-gradient(circle at top right, rgba(52, 211, 153, 0.04), transparent 22%),
-    linear-gradient(180deg, #08131f 0%, #07111a 38%, #08111a 100%);
-  --shell-bg:
-    radial-gradient(circle at 12% 10%, rgba(56, 189, 248, 0.06), transparent 24%),
-    radial-gradient(circle at 88% 4%, rgba(52, 211, 153, 0.05), transparent 20%),
-    linear-gradient(180deg, rgba(8, 17, 28, 0.98), rgba(7, 17, 26, 1));
-  --glow-bg:
-    radial-gradient(circle at 10% 14%, rgba(125, 211, 252, 0.06), transparent 28%),
-    radial-gradient(circle at 86% 0%, rgba(52, 211, 153, 0.05), transparent 26%);
-  --card-bg: linear-gradient(180deg, rgba(14, 24, 38, 0.98), rgba(8, 16, 26, 0.98));
-  --card-muted-bg: rgba(255, 255, 255, 0.075);
-  --card-muted-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.02);
-  --bottom-bar-bg: rgba(7, 17, 27, 0.78);
-  --footer-bg: rgba(4, 10, 18, 0.9);
-  --selection-bg: rgba(56, 189, 248, 0.32);
+    radial-gradient(ellipse at 15% 0%,  rgba(34, 197,  94, 0.07), transparent 30%),
+    radial-gradient(ellipse at 85% 5%,  rgba(56, 189, 248, 0.05), transparent 28%),
+    linear-gradient(180deg, #081320 0%, #060f18 40%, #060f18 100%);
 
-  --text-display: clamp(2.5rem, 5vw, 4.4rem);
-  --text-h1: clamp(1.85rem, 4.2vw, 3rem);
-  --text-h2: clamp(1.35rem, 2.5vw, 2rem);
-  --text-h3: clamp(1.05rem, 1.7vw, 1.2rem);
-  --text-body-lg: clamp(1rem, 1.4vw, 1.075rem);
-  --text-body: 0.95rem;
+  --shell-bg:
+    radial-gradient(ellipse at 10%  8%, rgba(74, 222, 128, 0.07), transparent 28%),
+    radial-gradient(ellipse at 90%  4%, rgba(56, 189, 248, 0.05), transparent 24%),
+    linear-gradient(180deg, rgba(8, 18, 30, 0.99), rgba(6, 15, 24, 1));
+
+  --glow-bg:
+    radial-gradient(ellipse at 8%  12%, rgba(74, 222, 128, 0.07), transparent 30%),
+    radial-gradient(ellipse at 88%  2%, rgba(56, 189, 248, 0.05), transparent 28%);
+
+  --card-bg:      linear-gradient(175deg, rgba(12, 24, 38, 0.99), rgba(7, 15, 24, 0.99));
+  --card-muted-bg:rgba(255, 255, 255, 0.065);
+  --card-muted-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.025);
+
+  --bottom-bar-bg: rgba(6, 14, 23, 0.82);
+  --footer-bg:     rgba(4,  9,  17, 0.92);
+  --selection-bg:  rgba(74, 222, 128, 0.28);
+
+  /* ── Typography ──────────────────────────────────── */
+  --text-display: clamp(2.6rem, 5.5vw, 4.6rem);
+  --text-h1:      clamp(1.9rem, 4.4vw,  3.1rem);
+  --text-h2:      clamp(1.35rem, 2.6vw, 2.05rem);
+  --text-h3:      clamp(1.05rem, 1.8vw, 1.25rem);
+  --text-body-lg: clamp(1rem,    1.4vw, 1.08rem);
+  --text-body:    0.95rem;
   --text-body-sm: 0.875rem;
   --text-caption: 0.75rem;
-  --text-label: 0.75rem;
+  --text-label:   0.72rem;
 
-  --space-1: 4px;
-  --space-2: 8px;
-  --space-3: 12px;
-  --space-4: 16px;
-  --space-6: 24px;
-  --space-8: 32px;
+  /* ── Spacing ─────────────────────────────────────── */
+  --space-1:  4px;
+  --space-2:  8px;
+  --space-3:  12px;
+  --space-4:  16px;
+  --space-6:  24px;
+  --space-8:  32px;
   --space-12: 48px;
   --space-16: 64px;
   --space-24: 96px;
   --space-32: 128px;
 
-  --radius-sm: 14px;
-  --radius-md: 18px;
-  --radius-lg: 24px;
-  --radius-xl: 32px;
+  /* ── Radii ───────────────────────────────────────── */
+  --radius-sm:   12px;
+  --radius-md:   16px;
+  --radius-lg:   22px;
+  --radius-xl:   30px;
   --radius-pill: 999px;
 
-  --container-inline: clamp(12px, 3vw, 28px);
+  /* ── Layout ──────────────────────────────────────── */
+  --container-inline: clamp(14px, 3vw, 28px);
   --container-max: 1240px;
-  --header-height: 62px;
+  --header-height: 64px;
   --bottom-nav-height: 68px;
 }
 
@@ -100,9 +128,7 @@ html {
 }
 
 @media (min-width: 1024px) {
-  html {
-    font-size: 14px;
-  }
+  html { font-size: 14px; }
 }
 
 body {
@@ -116,39 +142,23 @@ body {
   overflow-x: clip;
 }
 
-* {
-  border-color: var(--color-border);
-}
+* { border-color: var(--color-border); }
 
 *::selection {
   background: var(--selection-bg);
   color: var(--color-text-primary);
 }
 
-a,
-button,
-input,
-select,
-textarea {
-  transition-duration: 180ms;
-  transition-timing-function: cubic-bezier(0.2, 0.8, 0.2, 1);
+a, button, input, select, textarea {
+  transition-duration: 160ms;
+  transition-timing-function: cubic-bezier(0.22, 0.9, 0.22, 1);
 }
 
-button,
-select {
-  cursor: pointer;
-}
+button, select { cursor: pointer; }
+input, select, textarea { font-size: 1rem; }
+img { display: block; }
 
-input,
-select,
-textarea {
-  font-size: 1rem;
-}
-
-img {
-  display: block;
-}
-
+/* ── Shell ───────────────────────────────────────── */
 .app-shell {
   position: relative;
   background: var(--shell-bg);
@@ -158,6 +168,7 @@ img {
   background: var(--glow-bg);
 }
 
+/* ── Containers ──────────────────────────────────── */
 .site-container,
 .page-container {
   width: min(calc(100% - (var(--container-inline) * 2)), var(--container-max));
@@ -176,14 +187,16 @@ img {
   margin-top: clamp(var(--space-4), 2vw, var(--space-6));
 }
 
+/* ── Surface Cards ───────────────────────────────── */
 .surface-card,
 .glass-card {
   border-radius: var(--radius-lg);
   border: 1px solid var(--color-border-strong);
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.025), rgba(255, 255, 255, 0)), var(--card-bg);
+    linear-gradient(175deg, rgba(255, 255, 255, 0.028), rgba(255, 255, 255, 0.0)),
+    var(--card-bg);
   box-shadow: var(--shadow-card);
-  backdrop-filter: blur(18px);
+  backdrop-filter: blur(20px);
 }
 
 .surface-card-muted {
@@ -198,20 +211,21 @@ img {
   background: var(--color-control-bg);
 }
 
+/* ── Typography Utilities ────────────────────────── */
 .heading-kicker,
 .kicker {
   font-size: var(--text-label);
   font-weight: 700;
-  letter-spacing: 0.24em;
+  letter-spacing: 0.22em;
   text-transform: uppercase;
   color: var(--color-brand);
 }
 
 .page-title {
   font-size: var(--text-display);
-  line-height: 0.96;
-  font-weight: 750;
-  letter-spacing: -0.05em;
+  line-height: 0.94;
+  font-weight: 800;
+  letter-spacing: -0.055em;
   color: var(--color-text-primary);
 }
 
@@ -219,20 +233,20 @@ img {
   font-size: var(--text-h2);
   line-height: 1.02;
   font-weight: 700;
-  letter-spacing: -0.03em;
+  letter-spacing: -0.035em;
   color: var(--color-text-primary);
 }
 
 .body-lead {
   font-size: var(--text-body-lg);
-  line-height: 1.7;
+  line-height: 1.72;
   color: var(--color-text-secondary);
 }
 
 .body-copy,
 .muted-copy {
   color: var(--color-text-secondary);
-  line-height: 1.65;
+  line-height: 1.68;
 }
 
 .field-label {
@@ -243,61 +257,69 @@ img {
   color: var(--color-text-secondary);
 }
 
-.text-balance {
-  text-wrap: balance;
+.text-balance { text-wrap: balance; }
+
+/* ── Gradient text helper ────────────────────────── */
+.gradient-text {
+  background: linear-gradient(135deg, #ffffff 0%, #4ade80 72%, #22c55e 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
 }
 
+/* ── Table ───────────────────────────────────────── */
 .table-shell th {
   padding-bottom: var(--space-3);
   color: var(--color-text-muted);
-  font-size: 0.75rem;
+  font-size: 0.72rem;
   text-transform: uppercase;
   letter-spacing: 0.18em;
   font-weight: 700;
 }
 
-.table-shell td {
-  color: var(--color-text-secondary);
-}
+.table-shell td { color: var(--color-text-secondary); }
 
 .table-shell tr + tr {
   border-top: 1px solid var(--color-border);
 }
 
+/* ── Divider ─────────────────────────────────────── */
 .soft-divider {
   height: 1px;
   width: 100%;
   background: linear-gradient(90deg, transparent, var(--color-border-strong), transparent);
 }
 
+/* ── Animations ──────────────────────────────────── */
 @keyframes slideUp {
-  from {
-    transform: translateY(16px);
-    opacity: 0;
-  }
-  to {
-    transform: translateY(0);
-    opacity: 1;
-  }
+  from { transform: translateY(18px); opacity: 0; }
+  to   { transform: translateY(0);    opacity: 1; }
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
 }
 
 @keyframes pulseGlow {
-  0%,
-  100% {
-    box-shadow: 0 0 0 rgba(125, 211, 252, 0);
-  }
-  50% {
-    box-shadow: 0 0 0 8px rgba(125, 211, 252, 0.08);
-  }
+  0%,100% { box-shadow: 0 0 0 rgba(74, 222, 128, 0); }
+  50%      { box-shadow: 0 0 0 10px rgba(74, 222, 128, 0.07); }
 }
 
+@keyframes shimmer {
+  from { background-position: -200% center; }
+  to   { background-position:  200% center; }
+}
+
+/* ── Safe-area helpers ───────────────────────────── */
 .pb-safe {
   padding-bottom: env(safe-area-inset-bottom, 0px);
 }
 
+/* ── Bottom action bar ───────────────────────────── */
 .bottom-action-bar {
   position: fixed;
-  bottom: max(12px, env(safe-area-inset-bottom, 0px));
+  bottom: max(14px, env(safe-area-inset-bottom, 0px));
   left: 0;
   right: 0;
   z-index: 40;
@@ -306,27 +328,28 @@ img {
 }
 
 .bottom-action-bar > div {
-  border-radius: 22px;
+  border-radius: 24px;
   border: 1px solid var(--color-border-strong);
   background: var(--bottom-bar-bg);
   box-shadow: var(--shadow-elevated);
-  backdrop-filter: blur(20px);
+  backdrop-filter: blur(24px);
   padding: 10px;
 }
 
+/* ── Mobile sheet ────────────────────────────────── */
 .mobile-sheet {
-  border-radius: 28px 28px 0 0;
+  border-radius: 30px 30px 0 0;
   border: 1px solid var(--color-border-strong);
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0)), var(--card-bg);
+    linear-gradient(175deg, rgba(255, 255, 255, 0.038), rgba(255, 255, 255, 0)),
+    var(--card-bg);
   box-shadow: var(--shadow-elevated);
-  backdrop-filter: blur(24px);
+  backdrop-filter: blur(28px);
 }
 
+/* ── Responsive helpers ──────────────────────────── */
 @media (min-width: 768px) {
-  .bottom-action-bar {
-    display: none;
-  }
+  .bottom-action-bar { display: none; }
 }
 
 .has-bottom-nav {
@@ -334,29 +357,24 @@ img {
 }
 
 @media (min-width: 768px) {
-  .has-bottom-nav {
-    padding-bottom: 0;
-  }
+  .has-bottom-nav { padding-bottom: 0; }
 }
 
+/* ── Mobile overrides ────────────────────────────── */
 @media (max-width: 767px) {
   :root {
-    --header-height: 64px;
+    --header-height: 66px;
     --bottom-nav-height: 72px;
-    --radius-lg: 22px;
-    --radius-xl: 26px;
+    --radius-lg: 20px;
+    --radius-xl: 24px;
   }
 
-  .page-container {
-    padding-block: var(--space-4);
-  }
+  .page-container { padding-block: var(--space-4); }
 
-  .section-stack > * + * {
-    margin-top: var(--space-4);
-  }
+  .section-stack > * + * { margin-top: var(--space-4); }
 
   .surface-card,
   .glass-card {
-    box-shadow: 0 16px 38px rgba(2, 6, 23, 0.28);
+    box-shadow: 0 14px 36px rgba(1, 5, 14, 0.32);
   }
 }


### PR DESCRIPTION
## Summary

- **Brand color shift** — primary brand changes from sky-blue to pitch-green (`#4ade80`/`#22c55e`), which is semantically on-brand for a football platform. Sky-blue is kept as a meaningful secondary accent for the match/event product type.
- **Landing page hero overhaul** — the cluttered 3-column tile layout is replaced with a single bold headline using a white→green `gradient-text` treatment (*"Better pickup **football.**"*), stat pills in a compact header row, and distinct slot/match sections inside one hero card separated by soft dividers.
- **Color vocabulary for product types** — slot cards use green accents, match cards use blue. This creates a consistent visual language across the marketplace.
- **Buttons** — primary button is now a green gradient with a stronger shadow/glow on hover; secondary border highlights green on hover.
- **Header** — active nav links use green border/bg, wallet badge is green-accented, mobile menu is cleaner with a dedicated `MenuRow` helper and better section headers.
- **Footer** — logo wrapped in a green-tinted icon box, all link hover states turn green.
- **Smaller components** — Badge gains `warning`/`danger` variants; AppPageHeader gets a green gradient atmosphere; EmptyState icon circle is green-tinted; Input focus ring turns green.
- **Design tokens** (`globals.css`) — richer background gradients with green atmospheric glows, new `.gradient-text` utility class, `fadeIn`/`shimmer` keyframes, `--shadow-brand` token, tighter border-radius scale (12–30 px).

## What a reviewer should know

- All changes are purely presentational — no logic, API, or data model changes.
- TypeScript: zero errors in any modified file (pre-existing backend errors from missing Prisma client generation are unrelated).
- The Prisma-client build error that prevents `next build` from completing is a pre-existing infrastructure issue on this branch, not introduced here.
- CSS variables declared in `globals.css` propagate automatically to any component that uses them via `var(--color-brand)`, so most of the color shift requires no per-component edits.

## Test plan

- [ ] Landing page renders: hero headline visible with gradient text, stat pills in header, slot cards (green accents) and match cards (blue accents) in their respective sections
- [ ] Primary button across the app shows green gradient (Book a slot, Sign in, etc.)
- [ ] Header active link indicator shows green pill; wallet balance badge is green-tinted
- [ ] Mobile menu opens cleanly, active links highlighted in green
- [ ] Footer links hover to green; logo icon box has green tint
- [ ] Empty states show green-tinted icon circle
- [ ] Form inputs show green focus ring
- [ ] No visual regressions on /play, /profile, /host, /tickets pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)